### PR TITLE
sync_read,write以外のDynamixel関係の関数をDynamixelクラスへ移植する

### DIFF
--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -33,6 +33,12 @@ class DynamixelBase {
   std::string get_name() const { return name_; }
   virtual bool write_torque_enable(
     const dynamixel_base::comm_t & comm, const bool enable) { return false; }
+  virtual bool write_position_p_gain(
+    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
+  virtual bool write_position_i_gain(
+    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
+  virtual bool write_position_d_gain(
+    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
 
  protected:
   uint8_t id_;

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -46,6 +46,14 @@ class DynamixelBase {
   virtual bool write_velocity_i_gain(
     const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
 
+  virtual bool write_profile_acceleration(
+    const dynamixel_base::comm_t & comm, const double acceleration_rpss) { return false; }
+  virtual bool write_profile_velocity(
+    const dynamixel_base::comm_t & comm, const double velocity_rps) { return false; }
+
+  virtual unsigned int to_profile_acceleration(const double acceleration_rpss) { return 0; }
+  virtual unsigned int to_profile_velocity(const double velocity_rps) { return 0; }
+
  protected:
   uint8_t id_;
   std::string name_;

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -35,15 +35,15 @@ class DynamixelBase {
   virtual bool write_torque_enable(
     const dynamixel_base::comm_t & comm, const bool enable) { return false; }
 
-  virtual bool write_position_p_gain(
-    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
-  virtual bool write_position_i_gain(
-    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
-  virtual bool write_position_d_gain(
+  virtual bool write_velocity_i_gain(
     const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
   virtual bool write_velocity_p_gain(
     const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
-  virtual bool write_velocity_i_gain(
+  virtual bool write_position_d_gain(
+    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
+  virtual bool write_position_i_gain(
+    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
+  virtual bool write_position_p_gain(
     const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
 
   virtual bool write_profile_acceleration(

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -36,6 +36,12 @@ class DynamixelBase {
     const dynamixel_base::comm_t & comm, uint8_t & mode) { return false; }
   virtual bool write_operating_mode(
     const dynamixel_base::comm_t & comm, const uint8_t mode) { return false; }
+  virtual bool read_current_limit(
+    const dynamixel_base::comm_t & comm, double & limit_ampere) { return false; }
+  virtual bool read_max_position_limit(
+    const dynamixel_base::comm_t & comm, double & limit_radian) { return false; }
+  virtual bool read_min_position_limit(
+    const dynamixel_base::comm_t & comm, double & limit_radian) { return false; }
 
   virtual bool write_torque_enable(
     const dynamixel_base::comm_t & comm, const bool enable) { return false; }
@@ -56,8 +62,10 @@ class DynamixelBase {
   virtual bool write_profile_velocity(
     const dynamixel_base::comm_t & comm, const double velocity_rps) { return false; }
 
-  virtual unsigned int to_profile_acceleration(const double acceleration_rpss) { return 0; }
-  virtual unsigned int to_profile_velocity(const double velocity_rps) { return 0; }
+  virtual unsigned int to_profile_acceleration(const double acceleration_rpss) { return 1; }
+  virtual unsigned int to_profile_velocity(const double velocity_rps) { return 1; }
+  virtual double to_position_radian(const int position) { return 0.0; }
+  virtual double to_current_ampere(const int current) { return 0.0; }
 
  protected:
   uint8_t id_;

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -65,7 +65,12 @@ class DynamixelBase {
   virtual unsigned int to_profile_acceleration(const double acceleration_rpss) { return 1; }
   virtual unsigned int to_profile_velocity(const double velocity_rps) { return 1; }
   virtual double to_position_radian(const int position) { return 0.0; }
+  virtual double to_velocity_rps(const int velocity) { return 0.0; }
   virtual double to_current_ampere(const int current) { return 0.0; }
+  virtual double to_voltage_volt(const int voltage) { return 0.0; }
+  virtual unsigned int from_position_radian(const double position_rad) { return 0; }
+  virtual unsigned int from_velocity_rps(const double velocity_rps) { return 0; }
+  virtual unsigned int from_current_ampere(const double current_ampere) { return 0; }
 
  protected:
   uint8_t id_;

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -31,13 +31,19 @@ class DynamixelBase {
 
   uint8_t get_id() const { return id_; }
   std::string get_name() const { return name_; }
+
   virtual bool write_torque_enable(
     const dynamixel_base::comm_t & comm, const bool enable) { return false; }
+
   virtual bool write_position_p_gain(
     const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
   virtual bool write_position_i_gain(
     const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
   virtual bool write_position_d_gain(
+    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
+  virtual bool write_velocity_p_gain(
+    const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
+  virtual bool write_velocity_i_gain(
     const dynamixel_base::comm_t & comm, const unsigned int gain) { return false; }
 
  protected:

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -32,6 +32,11 @@ class DynamixelBase {
   uint8_t get_id() const { return id_; }
   std::string get_name() const { return name_; }
 
+  virtual bool read_operating_mode(
+    const dynamixel_base::comm_t & comm, uint8_t & mode) { return false; }
+  virtual bool write_operating_mode(
+    const dynamixel_base::comm_t & comm, const uint8_t mode) { return false; }
+
   virtual bool write_torque_enable(
     const dynamixel_base::comm_t & comm, const bool enable) { return false; }
 

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -25,11 +25,11 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
 
   bool write_torque_enable(const dynamixel_base::comm_t & comm, const bool enable);
 
-  bool write_position_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
-  bool write_position_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
-  bool write_position_d_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
-  bool write_velocity_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
   bool write_velocity_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_velocity_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_position_d_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_position_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_position_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
 
   bool write_profile_acceleration(
     const dynamixel_base::comm_t & comm, const double acceleration_rpss);

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -21,10 +21,13 @@ namespace dynamixel_xm {
 
 class DynamixelXM : public dynamixel_base::DynamixelBase  {
  public:
-  explicit DynamixelXM(const uint8_t id);
+  explicit DynamixelXM(const uint8_t id, const int home_position = 2048);
 
   bool read_operating_mode(const dynamixel_base::comm_t & comm, uint8_t & mode);
   bool write_operating_mode(const dynamixel_base::comm_t & comm, const uint8_t mode);
+  bool read_current_limit(const dynamixel_base::comm_t & comm, double & limit_ampere);
+  bool read_max_position_limit(const dynamixel_base::comm_t & comm, double & limit_radian);
+  bool read_min_position_limit(const dynamixel_base::comm_t & comm, double & limit_radian);
 
   bool write_torque_enable(const dynamixel_base::comm_t & comm, const bool enable);
 
@@ -41,6 +44,11 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
 
   unsigned int to_profile_acceleration(const double acceleration_rpss);
   unsigned int to_profile_velocity(const double velocity_rps);
+  double to_position_radian(const int position);
+  double to_current_ampere(const int current);
+
+ private:
+  int HOME_POSITION_;
 };
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -30,7 +30,6 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   bool write_position_d_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
   bool write_velocity_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
   bool write_velocity_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
-
 };
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -30,6 +30,14 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   bool write_position_d_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
   bool write_velocity_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
   bool write_velocity_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+
+  bool write_profile_acceleration(
+    const dynamixel_base::comm_t & comm, const double acceleration_rpss);
+  bool write_profile_velocity(
+    const dynamixel_base::comm_t & comm, const double velocity_rps);
+
+  unsigned int to_profile_acceleration(const double acceleration_rpss);
+  unsigned int to_profile_velocity(const double velocity_rps);
 };
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -45,7 +45,12 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   unsigned int to_profile_acceleration(const double acceleration_rpss);
   unsigned int to_profile_velocity(const double velocity_rps);
   double to_position_radian(const int position);
+  double to_velocity_rps(const int velocity);
   double to_current_ampere(const int current);
+  double to_voltage_volt(const int voltage);
+  unsigned int from_position_radian(const double position_rad);
+  unsigned int from_velocity_rps(const double velocity_rps);
+  unsigned int from_current_ampere(const double current_ampere);
 
  private:
   int HOME_POSITION_;

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -23,6 +23,9 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
  public:
   explicit DynamixelXM(const uint8_t id);
   bool write_torque_enable(const dynamixel_base::comm_t & comm, const bool enable);
+  bool write_position_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_position_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_position_d_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
 };
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -23,6 +23,9 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
  public:
   explicit DynamixelXM(const uint8_t id);
 
+  bool read_operating_mode(const dynamixel_base::comm_t & comm, uint8_t & mode);
+  bool write_operating_mode(const dynamixel_base::comm_t & comm, const uint8_t mode);
+
   bool write_torque_enable(const dynamixel_base::comm_t & comm, const bool enable);
 
   bool write_velocity_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -22,10 +22,15 @@ namespace dynamixel_xm {
 class DynamixelXM : public dynamixel_base::DynamixelBase  {
  public:
   explicit DynamixelXM(const uint8_t id);
+
   bool write_torque_enable(const dynamixel_base::comm_t & comm, const bool enable);
+
   bool write_position_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
   bool write_position_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
   bool write_position_d_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_velocity_p_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+  bool write_velocity_i_gain(const dynamixel_base::comm_t & comm, const unsigned int gain);
+
 };
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -88,8 +88,6 @@ class Hardware {
  protected:
   bool write_word_data_to_group(const std::string& group_name, const uint16_t address,
                                 const uint16_t write_data);
-  bool write_double_word_data_to_group(const std::string& group_name, const uint16_t address,
-                                       const uint32_t write_data);
 
   std::shared_ptr<hardware_communicator::Communicator> comm_;
 
@@ -110,8 +108,6 @@ class Hardware {
   uint32_t radian_to_dxl_pos(const double position);
   uint32_t to_dxl_velocity(const double velocity_rps);
   uint16_t to_dxl_current(const double current_ampere);
-  uint32_t to_dxl_acceleration(const double acceleration_rpss);
-  uint32_t to_dxl_profile_velocity(const double velocity_rps);
 
   hardware_joints::Joints joints_;
   std::map<JointGroupName, uint16_t> addr_sync_read_position_;

--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -101,9 +101,7 @@ class Hardware {
                             const uint16_t addr_target, const uint16_t len_target);
   void read_write_thread(const std::vector<std::string>& group_names,
                          const std::chrono::milliseconds& update_cycle_ms);
-  double dxl_pos_to_radian(const int32_t position);
   double dxl_velocity_to_rps(const int32_t velocity) const;
-  double dxl_current_to_ampere(const int16_t current) const;
   double dxl_voltage_to_volt(const int16_t voltage) const;
   uint32_t radian_to_dxl_pos(const double position);
   uint32_t to_dxl_velocity(const double velocity_rps);

--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -101,11 +101,6 @@ class Hardware {
                             const uint16_t addr_target, const uint16_t len_target);
   void read_write_thread(const std::vector<std::string>& group_names,
                          const std::chrono::milliseconds& update_cycle_ms);
-  double dxl_velocity_to_rps(const int32_t velocity) const;
-  double dxl_voltage_to_volt(const int16_t voltage) const;
-  uint32_t radian_to_dxl_pos(const double position);
-  uint32_t to_dxl_velocity(const double velocity_rps);
-  uint16_t to_dxl_current(const double current_ampere);
 
   hardware_joints::Joints joints_;
   std::map<JointGroupName, uint16_t> addr_sync_read_position_;

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -44,6 +44,9 @@ const double DXL_VELOCITY_FROM_RAD_PER_SEC = 1.0 / TO_VELOCITY_RAD_PER_SEC;
 const int DXL_MAX_VELOCITY = 32767;
 const double TO_RADIANS = (180.0 / 2048.0) * M_PI / 180.0;
 const double TO_CURRENT_AMPERE = 0.00269;
+const double TO_VOLTAGE_VOLT = 0.1;
+const double TO_DXL_POS = 1.0 / TO_RADIANS;
+const double TO_DXL_CURRENT = 1.0 / TO_CURRENT_AMPERE;
 
 DynamixelXM::DynamixelXM(const uint8_t id, const int home_position)
   : dynamixel_base::DynamixelBase(id), HOME_POSITION_(home_position) {
@@ -157,8 +160,28 @@ double DynamixelXM::to_position_radian(const int position) {
   return (position - HOME_POSITION_) * TO_RADIANS;
 }
 
+double DynamixelXM::to_velocity_rps(const int velocity) {
+  return velocity * TO_VELOCITY_RAD_PER_SEC;
+}
+
 double DynamixelXM::to_current_ampere(const int current) {
   return current * TO_CURRENT_AMPERE;
+}
+
+double DynamixelXM::to_voltage_volt(const int voltage) {
+  return voltage * TO_VOLTAGE_VOLT;
+}
+
+unsigned int DynamixelXM::from_position_radian(const double position_rad) {
+  return position_rad * TO_DXL_POS + HOME_POSITION_;
+}
+
+unsigned int DynamixelXM::from_velocity_rps(const double velocity_rps) {
+  return velocity_rps * DXL_VELOCITY_FROM_RAD_PER_SEC;
+}
+
+unsigned int DynamixelXM::from_current_ampere(const double current_ampere) {
+  return current_ampere * TO_DXL_CURRENT;
 }
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -19,6 +19,7 @@
 
 namespace dynamixel_xm {
 
+const uint16_t ADDR_OPERATING_MODE = 11;
 const uint16_t ADDR_TORQUE_ENABLE = 64;
 const uint16_t ADDR_VELOCITY_I_GAIN = 76;
 const uint16_t ADDR_VELOCITY_P_GAIN = 78;
@@ -42,6 +43,14 @@ const int DXL_MAX_VELOCITY = 32767;
 DynamixelXM::DynamixelXM(const uint8_t id)
   : dynamixel_base::DynamixelBase(id) {
   name_ = "XM";
+}
+
+bool DynamixelXM::read_operating_mode(const dynamixel_base::comm_t & comm, uint8_t & mode) {
+  return comm->read_byte_data(id_, ADDR_OPERATING_MODE, mode);
+}
+
+bool DynamixelXM::write_operating_mode(const dynamixel_base::comm_t & comm, const uint8_t mode) {
+  return comm->write_byte_data(id_, ADDR_OPERATING_MODE, mode);
 }
 
 bool DynamixelXM::write_torque_enable(const dynamixel_base::comm_t & comm, const bool enable) {

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -19,6 +19,9 @@
 namespace dynamixel_xm {
 
 const uint16_t ADDR_TORQUE_ENABLE = 64;
+const uint16_t ADDR_POSITION_D_GAIN = 80;
+const uint16_t ADDR_POSITION_I_GAIN = 82;
+const uint16_t ADDR_POSITION_P_GAIN = 84;
 
 DynamixelXM::DynamixelXM(const uint8_t id)
   : dynamixel_base::DynamixelBase(id) {
@@ -27,6 +30,21 @@ DynamixelXM::DynamixelXM(const uint8_t id)
 
 bool DynamixelXM::write_torque_enable(const dynamixel_base::comm_t & comm, const bool enable) {
   return comm->write_byte_data(id_, ADDR_TORQUE_ENABLE, enable);
+}
+
+bool DynamixelXM::write_position_p_gain(
+  const dynamixel_base::comm_t & comm, const unsigned int gain) {
+  return comm->write_word_data(id_, ADDR_POSITION_P_GAIN, static_cast<uint16_t>(gain));
+}
+
+bool DynamixelXM::write_position_i_gain(
+  const dynamixel_base::comm_t & comm, const unsigned int gain) {
+  return comm->write_word_data(id_, ADDR_POSITION_I_GAIN, static_cast<uint16_t>(gain));
+}
+
+bool DynamixelXM::write_position_d_gain(
+  const dynamixel_base::comm_t & comm, const unsigned int gain) {
+  return comm->write_word_data(id_, ADDR_POSITION_D_GAIN, static_cast<uint16_t>(gain));
 }
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -48,19 +48,9 @@ bool DynamixelXM::write_torque_enable(const dynamixel_base::comm_t & comm, const
   return comm->write_byte_data(id_, ADDR_TORQUE_ENABLE, enable);
 }
 
-bool DynamixelXM::write_position_p_gain(
+bool DynamixelXM::write_velocity_i_gain(
   const dynamixel_base::comm_t & comm, const unsigned int gain) {
-  return comm->write_word_data(id_, ADDR_POSITION_P_GAIN, static_cast<uint16_t>(gain));
-}
-
-bool DynamixelXM::write_position_i_gain(
-  const dynamixel_base::comm_t & comm, const unsigned int gain) {
-  return comm->write_word_data(id_, ADDR_POSITION_I_GAIN, static_cast<uint16_t>(gain));
-}
-
-bool DynamixelXM::write_position_d_gain(
-  const dynamixel_base::comm_t & comm, const unsigned int gain) {
-  return comm->write_word_data(id_, ADDR_POSITION_D_GAIN, static_cast<uint16_t>(gain));
+  return comm->write_word_data(id_, ADDR_VELOCITY_I_GAIN, static_cast<uint16_t>(gain));
 }
 
 bool DynamixelXM::write_velocity_p_gain(
@@ -68,9 +58,19 @@ bool DynamixelXM::write_velocity_p_gain(
   return comm->write_word_data(id_, ADDR_VELOCITY_P_GAIN, static_cast<uint16_t>(gain));
 }
 
-bool DynamixelXM::write_velocity_i_gain(
+bool DynamixelXM::write_position_d_gain(
   const dynamixel_base::comm_t & comm, const unsigned int gain) {
-  return comm->write_word_data(id_, ADDR_VELOCITY_I_GAIN, static_cast<uint16_t>(gain));
+  return comm->write_word_data(id_, ADDR_POSITION_D_GAIN, static_cast<uint16_t>(gain));
+}
+
+bool DynamixelXM::write_position_i_gain(
+  const dynamixel_base::comm_t & comm, const unsigned int gain) {
+  return comm->write_word_data(id_, ADDR_POSITION_I_GAIN, static_cast<uint16_t>(gain));
+}
+
+bool DynamixelXM::write_position_p_gain(
+  const dynamixel_base::comm_t & comm, const unsigned int gain) {
+  return comm->write_word_data(id_, ADDR_POSITION_P_GAIN, static_cast<uint16_t>(gain));
 }
 
 bool DynamixelXM::write_profile_acceleration(

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -19,6 +19,8 @@
 namespace dynamixel_xm {
 
 const uint16_t ADDR_TORQUE_ENABLE = 64;
+const uint16_t ADDR_VELOCITY_I_GAIN = 76;
+const uint16_t ADDR_VELOCITY_P_GAIN = 78;
 const uint16_t ADDR_POSITION_D_GAIN = 80;
 const uint16_t ADDR_POSITION_I_GAIN = 82;
 const uint16_t ADDR_POSITION_P_GAIN = 84;
@@ -45,6 +47,16 @@ bool DynamixelXM::write_position_i_gain(
 bool DynamixelXM::write_position_d_gain(
   const dynamixel_base::comm_t & comm, const unsigned int gain) {
   return comm->write_word_data(id_, ADDR_POSITION_D_GAIN, static_cast<uint16_t>(gain));
+}
+
+bool DynamixelXM::write_velocity_p_gain(
+  const dynamixel_base::comm_t & comm, const unsigned int gain) {
+  return comm->write_word_data(id_, ADDR_VELOCITY_P_GAIN, static_cast<uint16_t>(gain));
+}
+
+bool DynamixelXM::write_velocity_i_gain(
+  const dynamixel_base::comm_t & comm, const unsigned int gain) {
+  return comm->write_word_data(id_, ADDR_VELOCITY_I_GAIN, static_cast<uint16_t>(gain));
 }
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 
 #include "dynamixel_xm.hpp"
 
@@ -24,6 +25,19 @@ const uint16_t ADDR_VELOCITY_P_GAIN = 78;
 const uint16_t ADDR_POSITION_D_GAIN = 80;
 const uint16_t ADDR_POSITION_I_GAIN = 82;
 const uint16_t ADDR_POSITION_P_GAIN = 84;
+const uint16_t ADDR_PROFILE_ACCELERATION = 108;
+const uint16_t ADDR_PROFILE_VELOCITY = 112;
+
+const double TO_ACCELERATION_REV_PER_MM = 214.577;
+const double TO_ACCELERATION_TO_RAD_PER_MM = TO_ACCELERATION_REV_PER_MM * 2.0 * M_PI;
+const double TO_ACCELERATION_TO_RAD_PER_SS = TO_ACCELERATION_TO_RAD_PER_MM / 3600.0;
+const double DXL_ACCELERATION_FROM_RAD_PER_SS = 1.0 / TO_ACCELERATION_TO_RAD_PER_SS;
+const int DXL_MAX_ACCELERATION = 32767;
+const double TO_VELOCITY_REV_PER_MIN = 0.229;
+const double TO_VELOCITY_RAD_PER_MIN = TO_VELOCITY_REV_PER_MIN * 2.0 * M_PI;
+const double TO_VELOCITY_RAD_PER_SEC = TO_VELOCITY_RAD_PER_MIN / 60.0;
+const double DXL_VELOCITY_FROM_RAD_PER_SEC = 1.0 / TO_VELOCITY_RAD_PER_SEC;
+const int DXL_MAX_VELOCITY = 32767;
 
 DynamixelXM::DynamixelXM(const uint8_t id)
   : dynamixel_base::DynamixelBase(id) {
@@ -57,6 +71,48 @@ bool DynamixelXM::write_velocity_p_gain(
 bool DynamixelXM::write_velocity_i_gain(
   const dynamixel_base::comm_t & comm, const unsigned int gain) {
   return comm->write_word_data(id_, ADDR_VELOCITY_I_GAIN, static_cast<uint16_t>(gain));
+}
+
+bool DynamixelXM::write_profile_acceleration(
+  const dynamixel_base::comm_t & comm, const double acceleration_rpss) {
+  return comm->write_double_word_data(
+    id_,
+    ADDR_PROFILE_ACCELERATION,
+    static_cast<uint32_t>(to_profile_acceleration(acceleration_rpss)));
+}
+
+bool DynamixelXM::write_profile_velocity(
+  const dynamixel_base::comm_t & comm, const double velocity_rps) {
+  return comm->write_double_word_data(
+    id_,
+    ADDR_PROFILE_VELOCITY,
+    static_cast<uint32_t>(to_profile_velocity(velocity_rps)));
+}
+
+unsigned int DynamixelXM::to_profile_acceleration(const double acceleration_rpss) {
+  int dxl_acceleration = DXL_ACCELERATION_FROM_RAD_PER_SS * acceleration_rpss;
+  if (dxl_acceleration > DXL_MAX_ACCELERATION) {
+    dxl_acceleration = DXL_MAX_ACCELERATION;
+  } else if (dxl_acceleration <= 0) {
+    // XMシリーズでは、'0'が最大加速度を意味する
+    // よって、加速度の最小値は'1'である
+    dxl_acceleration = 1;
+  }
+
+  return static_cast<unsigned int>(dxl_acceleration);
+}
+
+unsigned int DynamixelXM::to_profile_velocity(const double velocity_rps) {
+  int dxl_velocity = DXL_VELOCITY_FROM_RAD_PER_SEC * velocity_rps;
+  if (dxl_velocity > DXL_MAX_VELOCITY) {
+    dxl_velocity = DXL_MAX_VELOCITY;
+  } else if (dxl_velocity <= 0) {
+    // XMシリーズでは、'0'が最大速度を意味する
+    // よって、速度の最小値は'1'である
+    dxl_velocity = 1;
+  }
+
+  return static_cast<unsigned int>(dxl_velocity);
 }
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/src/hardware.cpp
+++ b/rt_manipulators_lib/src/hardware.cpp
@@ -37,7 +37,6 @@ const double TO_DXL_CURRENT = 1.0 / TO_CURRENT_AMPERE;
 const double TO_VOLTAGE_VOLT = 0.1;
 
 // Dynamixel XM Series address table
-const uint16_t ADDR_OPERATING_MODE = 11;
 const uint16_t ADDR_CURRENT_LIMIT = 38;
 const uint16_t ADDR_MAX_POSITION_LIMIT = 48;
 const uint16_t ADDR_MIN_POSITION_LIMIT = 52;
@@ -726,15 +725,14 @@ bool Hardware::write_operating_mode(const std::string& group_name) {
       return false;
     }
 
-    auto id = joints_.joint(joint_name)->id();
     uint8_t present_ope_mode;
-    if (!comm_->read_byte_data(id, ADDR_OPERATING_MODE, present_ope_mode)) {
+    if (!joints_.joint(joint_name)->dxl->read_operating_mode(comm_, present_ope_mode)) {
       std::cout << joint_name << "ジョイントのOperating Modeを読み取れません." << std::endl;
       return false;
     }
 
     if (target_ope_mode != present_ope_mode) {
-      if (!comm_->write_byte_data(id, ADDR_OPERATING_MODE, target_ope_mode)) {
+      if (!joints_.joint(joint_name)->dxl->write_operating_mode(comm_, target_ope_mode)) {
         std::cout << joint_name << "ジョイントにOperating Modeを書き込めません." << std::endl;
         std::cout << "トルクがONになっている場合はOFFしてください." << std::endl;
         return false;

--- a/rt_manipulators_lib/src/hardware.cpp
+++ b/rt_manipulators_lib/src/hardware.cpp
@@ -46,8 +46,6 @@ const uint16_t ADDR_OPERATING_MODE = 11;
 const uint16_t ADDR_CURRENT_LIMIT = 38;
 const uint16_t ADDR_MAX_POSITION_LIMIT = 48;
 const uint16_t ADDR_MIN_POSITION_LIMIT = 52;
-const uint16_t ADDR_VELOCITY_I_GAIN = 76;
-const uint16_t ADDR_VELOCITY_P_GAIN = 78;
 const uint16_t ADDR_GOAL_CURRENT = 102;
 const uint16_t ADDR_GOAL_VELOCITY = 104;
 const uint16_t ADDR_GOAL_POSITION = 116;
@@ -656,13 +654,13 @@ bool Hardware::write_velocity_pi_gain(const uint8_t id, const uint16_t p, const 
     return false;
   }
 
-  if (!comm_->write_word_data(id, ADDR_VELOCITY_P_GAIN, p)) {
+  if (!joints_.joint(id)->dxl->write_velocity_p_gain(comm_, p)) {
     std::cerr << "ID:" << std::to_string(id);
     std::cerr << "のVelocity P Gainの書き込みに失敗しました." << std::endl;
     return false;
   }
 
-  if (!comm_->write_word_data(id, ADDR_VELOCITY_I_GAIN, i)) {
+  if (!joints_.joint(id)->dxl->write_velocity_i_gain(comm_, i)) {
     std::cerr << "ID:" << std::to_string(id);
     std::cerr << "のVelocity I Gainの書き込みに失敗しました." << std::endl;
     return false;
@@ -690,16 +688,11 @@ bool Hardware::write_velocity_pi_gain_to_group(const std::string& group_name, co
     return false;
   }
 
-  if (!write_word_data_to_group(group_name, ADDR_VELOCITY_P_GAIN, p)) {
-    std::cerr << group_name << "グループのVelocity P Gainの書き込みに失敗しました." << std::endl;
-    return false;
+  for (const auto & joint_name : joints_.group(group_name)->joint_names()) {
+    if (!write_velocity_pi_gain(joint_name, p, i)) {
+      return false;
+    }
   }
-
-  if (!write_word_data_to_group(group_name, ADDR_VELOCITY_I_GAIN, i)) {
-    std::cerr << group_name << "グループのVelocity I Gainの書き込みに失敗しました." << std::endl;
-    return false;
-  }
-
   return true;
 }
 

--- a/rt_manipulators_lib/src/hardware.cpp
+++ b/rt_manipulators_lib/src/hardware.cpp
@@ -48,9 +48,6 @@ const uint16_t ADDR_MAX_POSITION_LIMIT = 48;
 const uint16_t ADDR_MIN_POSITION_LIMIT = 52;
 const uint16_t ADDR_VELOCITY_I_GAIN = 76;
 const uint16_t ADDR_VELOCITY_P_GAIN = 78;
-const uint16_t ADDR_POSITION_D_GAIN = 80;
-const uint16_t ADDR_POSITION_I_GAIN = 82;
-const uint16_t ADDR_POSITION_P_GAIN = 84;
 const uint16_t ADDR_GOAL_CURRENT = 102;
 const uint16_t ADDR_GOAL_VELOCITY = 104;
 const uint16_t ADDR_GOAL_POSITION = 116;
@@ -604,19 +601,19 @@ bool Hardware::write_position_pid_gain(const uint8_t id, const uint16_t p, const
     return false;
   }
 
-  if (!comm_->write_word_data(id, ADDR_POSITION_P_GAIN, p)) {
+  if (!joints_.joint(id)->dxl->write_position_p_gain(comm_, p)) {
     std::cerr << "ID:" << std::to_string(id);
     std::cerr << "のPosition P Gainの書き込みに失敗しました." << std::endl;
     return false;
   }
 
-  if (!comm_->write_word_data(id, ADDR_POSITION_I_GAIN, i)) {
+  if (!joints_.joint(id)->dxl->write_position_i_gain(comm_, i)) {
     std::cerr << "ID:" << std::to_string(id);
     std::cerr << "のPosition I Gainの書き込みに失敗しました." << std::endl;
     return false;
   }
 
-  if (!comm_->write_word_data(id, ADDR_POSITION_D_GAIN, d)) {
+  if (!joints_.joint(id)->dxl->write_position_d_gain(comm_, d)) {
     std::cerr << "ID:" << std::to_string(id);
     std::cerr << "のPosition D Gainの書き込みに失敗しました." << std::endl;
     return false;
@@ -644,21 +641,11 @@ bool Hardware::write_position_pid_gain_to_group(const std::string& group_name, c
     return false;
   }
 
-  if (!write_word_data_to_group(group_name, ADDR_POSITION_P_GAIN, p)) {
-    std::cerr << group_name << "グループのPosition P Gainの書き込みに失敗しました." << std::endl;
-    return false;
+  for (const auto & joint_name : joints_.group(group_name)->joint_names()) {
+    if (!write_position_pid_gain(joint_name, p, i, d)) {
+      return false;
+    }
   }
-
-  if (!write_word_data_to_group(group_name, ADDR_POSITION_I_GAIN, i)) {
-    std::cerr << group_name << "グループのPosition I Gainの書き込みに失敗しました." << std::endl;
-    return false;
-  }
-
-  if (!write_word_data_to_group(group_name, ADDR_POSITION_D_GAIN, d)) {
-    std::cerr << group_name << "グループのPosition D Gainの書き込みに失敗しました." << std::endl;
-    return false;
-  }
-
   return true;
 }
 

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -61,3 +61,11 @@ TEST_F(XMTestFixture, write_position_i_gain) {
 TEST_F(XMTestFixture, write_position_d_gain) {
   ASSERT_FALSE(dxl->write_position_d_gain(comm, 123));
 }
+
+TEST_F(XMTestFixture, write_velocity_p_gain) {
+  ASSERT_FALSE(dxl->write_velocity_p_gain(comm, 123));
+}
+
+TEST_F(XMTestFixture, write_velocity_i_gain) {
+  ASSERT_FALSE(dxl->write_velocity_i_gain(comm, 123));
+}

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -49,3 +49,15 @@ TEST_F(XMTestFixture, write_torque_enable) {
   // Dynamixelが接続されていないため、通信が関わるテストはFalseを返す
   ASSERT_FALSE(dxl->write_torque_enable(comm, false));
 }
+
+TEST_F(XMTestFixture, write_position_p_gain) {
+  ASSERT_FALSE(dxl->write_position_p_gain(comm, 123));
+}
+
+TEST_F(XMTestFixture, write_position_i_gain) {
+  ASSERT_FALSE(dxl->write_position_i_gain(comm, 123));
+}
+
+TEST_F(XMTestFixture, write_position_d_gain) {
+  ASSERT_FALSE(dxl->write_position_d_gain(comm, 123));
+}

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -50,24 +50,24 @@ TEST_F(XMTestFixture, write_torque_enable) {
   ASSERT_FALSE(dxl->write_torque_enable(comm, false));
 }
 
-TEST_F(XMTestFixture, write_position_p_gain) {
-  ASSERT_FALSE(dxl->write_position_p_gain(comm, 123));
-}
-
-TEST_F(XMTestFixture, write_position_i_gain) {
-  ASSERT_FALSE(dxl->write_position_i_gain(comm, 123));
-}
-
-TEST_F(XMTestFixture, write_position_d_gain) {
-  ASSERT_FALSE(dxl->write_position_d_gain(comm, 123));
+TEST_F(XMTestFixture, write_velocity_i_gain) {
+  ASSERT_FALSE(dxl->write_velocity_i_gain(comm, 123));
 }
 
 TEST_F(XMTestFixture, write_velocity_p_gain) {
   ASSERT_FALSE(dxl->write_velocity_p_gain(comm, 123));
 }
 
-TEST_F(XMTestFixture, write_velocity_i_gain) {
-  ASSERT_FALSE(dxl->write_velocity_i_gain(comm, 123));
+TEST_F(XMTestFixture, write_position_d_gain) {
+  ASSERT_FALSE(dxl->write_position_d_gain(comm, 123));
+}
+
+TEST_F(XMTestFixture, write_position_i_gain) {
+  ASSERT_FALSE(dxl->write_position_i_gain(comm, 123));
+}
+
+TEST_F(XMTestFixture, write_position_p_gain) {
+  ASSERT_FALSE(dxl->write_position_p_gain(comm, 123));
 }
 
 TEST_F(XMTestFixture, write_profile_acceleration) {

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -127,8 +127,38 @@ TEST_F(XMTestFixture, to_position_radian) {
   EXPECT_DOUBLE_EQ(dxl->to_position_radian(2048 - 1024), -M_PI_2);
 }
 
+TEST_F(XMTestFixture, to_velocity_rps) {
+  EXPECT_DOUBLE_EQ(dxl->to_velocity_rps(0), 0.0);
+  EXPECT_NEAR(dxl->to_velocity_rps(1), 0.0239808, 0.0001);
+  EXPECT_NEAR(dxl->to_velocity_rps(-1), -0.0239808, 0.0001);
+}
+
 TEST_F(XMTestFixture, to_current_ampere) {
   EXPECT_DOUBLE_EQ(dxl->to_current_ampere(0), 0.0);
   EXPECT_DOUBLE_EQ(dxl->to_current_ampere(1000), 2.69);
   EXPECT_DOUBLE_EQ(dxl->to_current_ampere(-1000), -2.69);
+}
+
+TEST_F(XMTestFixture, to_voltage_volt) {
+  EXPECT_DOUBLE_EQ(dxl->to_voltage_volt(0), 0.0);
+  EXPECT_DOUBLE_EQ(dxl->to_voltage_volt(1), 0.1);
+  EXPECT_DOUBLE_EQ(dxl->to_voltage_volt(2), 0.2);
+}
+
+TEST_F(XMTestFixture, from_position_radian) {
+  EXPECT_EQ(dxl->from_position_radian(0.0), 2048);
+  EXPECT_EQ(dxl->from_position_radian(M_PI_2), 2048 + 1024);
+  EXPECT_EQ(dxl->from_position_radian(-M_PI_2), 2048 - 1024);
+}
+
+TEST_F(XMTestFixture, from_velocity_rps) {
+  EXPECT_EQ(dxl->from_velocity_rps(0.0), 0);
+  EXPECT_EQ(dxl->from_velocity_rps(0.239809), 10);
+  EXPECT_EQ(dxl->from_velocity_rps(-0.239809), 0xFFFFFFF6);  // -10
+}
+
+TEST_F(XMTestFixture, from_current_ampere) {
+  EXPECT_EQ(dxl->from_current_ampere(0.0), 0);
+  EXPECT_EQ(dxl->from_current_ampere(2.691), 1000);
+  EXPECT_EQ(dxl->from_current_ampere(-2.691), 0xFFFFFC18);  // -1000
 }

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <memory>
 
 #include "gtest/gtest.h"
@@ -53,6 +54,21 @@ TEST_F(XMTestFixture, read_operating_mode) {
 
 TEST_F(XMTestFixture, write_operating_mode) {
   ASSERT_FALSE(dxl->write_operating_mode(comm, false));
+}
+
+TEST_F(XMTestFixture, read_current_limit) {
+  double limit;
+  ASSERT_FALSE(dxl->read_current_limit(comm, limit));
+}
+
+TEST_F(XMTestFixture, read_max_position_limit) {
+  double limit;
+  ASSERT_FALSE(dxl->read_max_position_limit(comm, limit));
+}
+
+TEST_F(XMTestFixture, read_min_position_limit) {
+  double limit;
+  ASSERT_FALSE(dxl->read_min_position_limit(comm, limit));
 }
 
 TEST_F(XMTestFixture, write_torque_enable) {
@@ -103,4 +119,16 @@ TEST_F(XMTestFixture, to_profile_velocity) {
   EXPECT_EQ(dxl->to_profile_velocity(0), 1);
   EXPECT_EQ(dxl->to_profile_velocity(0.239809), 10);
   EXPECT_EQ(dxl->to_profile_velocity(1000000), 32767);
+}
+
+TEST_F(XMTestFixture, to_position_radian) {
+  EXPECT_DOUBLE_EQ(dxl->to_position_radian(2048), 0.0);
+  EXPECT_DOUBLE_EQ(dxl->to_position_radian(2048 + 1024), M_PI_2);
+  EXPECT_DOUBLE_EQ(dxl->to_position_radian(2048 - 1024), -M_PI_2);
+}
+
+TEST_F(XMTestFixture, to_current_ampere) {
+  EXPECT_DOUBLE_EQ(dxl->to_current_ampere(0), 0.0);
+  EXPECT_DOUBLE_EQ(dxl->to_current_ampere(1000), 2.69);
+  EXPECT_DOUBLE_EQ(dxl->to_current_ampere(-1000), -2.69);
 }

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -69,3 +69,29 @@ TEST_F(XMTestFixture, write_velocity_p_gain) {
 TEST_F(XMTestFixture, write_velocity_i_gain) {
   ASSERT_FALSE(dxl->write_velocity_i_gain(comm, 123));
 }
+
+TEST_F(XMTestFixture, write_profile_acceleration) {
+  ASSERT_FALSE(dxl->write_profile_acceleration(comm, 0));
+}
+
+TEST_F(XMTestFixture, write_profile_velocity) {
+  ASSERT_FALSE(dxl->write_profile_velocity(comm, 0));
+}
+
+TEST_F(XMTestFixture, to_profile_acceleration) {
+  // rad/s^2 to rev/min^2
+  // 0以下に対しては1を返すことを期待
+  EXPECT_EQ(dxl->to_profile_acceleration(-1), 1);
+  EXPECT_EQ(dxl->to_profile_acceleration(0), 1);
+  EXPECT_EQ(dxl->to_profile_acceleration(3.745076), 10);
+  EXPECT_EQ(dxl->to_profile_acceleration(1000000), 32767);
+}
+
+TEST_F(XMTestFixture, to_profile_velocity) {
+  // rad/s to rev/min
+  // 0以下に対しては1を返すことを期待
+  EXPECT_EQ(dxl->to_profile_velocity(-1), 1);
+  EXPECT_EQ(dxl->to_profile_velocity(0), 1);
+  EXPECT_EQ(dxl->to_profile_velocity(0.239809), 10);
+  EXPECT_EQ(dxl->to_profile_velocity(1000000), 32767);
+}

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -45,8 +45,17 @@ TEST_F(XMTestFixture, get_id) {
   ASSERT_EQ(dxl->get_id(), 1);
 }
 
-TEST_F(XMTestFixture, write_torque_enable) {
+TEST_F(XMTestFixture, read_operating_mode) {
+  uint8_t mode;
   // Dynamixelが接続されていないため、通信が関わるテストはFalseを返す
+  ASSERT_FALSE(dxl->read_operating_mode(comm, mode));
+}
+
+TEST_F(XMTestFixture, write_operating_mode) {
+  ASSERT_FALSE(dxl->write_operating_mode(comm, false));
+}
+
+TEST_F(XMTestFixture, write_torque_enable) {
   ASSERT_FALSE(dxl->write_torque_enable(comm, false));
 }
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

sync_read, sync_write, インダイレクトアドレスの設定以外のDynamixel機能を
Dynamixelクラスへ移植します。

ライブラリのAPI変更はありません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

CRANE-X7実機で下記のサンプルを実行し、実行結果に変化が無いことを確認しています。

- x7_read_present_values : 特に、速度、電流値が異常値を示していないことを確認
- x7_write_position
- x7_write_velocity
- x7_write_current

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
