### PR TITLE
sync_read, sync_write関連をDynamixelクラスへ移植

### DIFF
--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -72,6 +72,26 @@ class DynamixelBase {
   virtual unsigned int from_velocity_rps(const double velocity_rps) { return 0; }
   virtual unsigned int from_current_ampere(const double current_ampere) { return 0; }
 
+  virtual bool auto_set_indirect_address_of_present_position(
+    const dynamixel_base::comm_t & comm) { return false; }
+  virtual bool auto_set_indirect_address_of_present_velocity(
+    const dynamixel_base::comm_t & comm) { return false; }
+  virtual bool auto_set_indirect_address_of_present_current(
+    const dynamixel_base::comm_t & comm) { return false; }
+  virtual bool auto_set_indirect_address_of_present_input_voltage(
+    const dynamixel_base::comm_t & comm) { return false; }
+  virtual bool auto_set_indirect_address_of_present_temperature(
+    const dynamixel_base::comm_t & comm) { return false; }
+
+  virtual unsigned int indirect_addr_of_present_position(void) { return 0; }
+  virtual unsigned int indirect_addr_of_present_velocity(void) { return 0; }
+  virtual unsigned int indirect_addr_of_present_current(void) { return 0; }
+  virtual unsigned int indirect_addr_of_present_input_voltage(void) { return 0; }
+  virtual unsigned int indirect_addr_of_present_temperature(void) { return 0; }
+
+  virtual unsigned int start_address_for_indirect_read(void) { return 0; }
+  virtual unsigned int length_of_indirect_data_read(void) { return 0; }
+
  protected:
   uint8_t id_;
   std::string name_;

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -91,6 +91,11 @@ class DynamixelBase {
 
   virtual unsigned int start_address_for_indirect_read(void) { return 0; }
   virtual unsigned int length_of_indirect_data_read(void) { return 0; }
+  virtual unsigned int next_indirect_addr_read(void) const { return 0; }
+
+  virtual bool extract_present_position_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & position_rad) { return false; }
 
  protected:
   uint8_t id_;

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "hardware_communicator.hpp"
 
@@ -121,6 +122,13 @@ class DynamixelBase {
   virtual bool extract_present_temperature_from_sync_read(
     const dynamixel_base::comm_t & comm, const std::string & group_name,
     int & temperature_deg) { return false; }
+
+  virtual void push_back_position_for_sync_write(
+    const double position_rad, std::vector<uint8_t> & write_data) {}
+  virtual void push_back_velocity_for_sync_write(
+    const double velocity_rps, std::vector<uint8_t> & write_data) {}
+  virtual void push_back_current_for_sync_write(
+    const double current_ampere, std::vector<uint8_t> & write_data) {}
 
  protected:
   uint8_t id_;

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -82,16 +82,29 @@ class DynamixelBase {
     const dynamixel_base::comm_t & comm) { return false; }
   virtual bool auto_set_indirect_address_of_present_temperature(
     const dynamixel_base::comm_t & comm) { return false; }
+  virtual bool auto_set_indirect_address_of_goal_position(
+    const dynamixel_base::comm_t & comm) { return false; }
+  virtual bool auto_set_indirect_address_of_goal_velocity(
+    const dynamixel_base::comm_t & comm) { return false; }
+  virtual bool auto_set_indirect_address_of_goal_current(
+    const dynamixel_base::comm_t & comm) { return false; }
 
   virtual unsigned int indirect_addr_of_present_position(void) { return 0; }
   virtual unsigned int indirect_addr_of_present_velocity(void) { return 0; }
   virtual unsigned int indirect_addr_of_present_current(void) { return 0; }
   virtual unsigned int indirect_addr_of_present_input_voltage(void) { return 0; }
   virtual unsigned int indirect_addr_of_present_temperature(void) { return 0; }
+  virtual unsigned int indirect_addr_of_goal_position(void) { return 0; }
+  virtual unsigned int indirect_addr_of_goal_velocity(void) { return 0; }
+  virtual unsigned int indirect_addr_of_goal_current(void) { return 0; }
 
   virtual unsigned int start_address_for_indirect_read(void) { return 0; }
   virtual unsigned int length_of_indirect_data_read(void) { return 0; }
   virtual unsigned int next_indirect_addr_read(void) const { return 0; }
+
+  virtual unsigned int start_address_for_indirect_write(void) { return 0; }
+  virtual unsigned int length_of_indirect_data_write(void) { return 0; }
+  virtual unsigned int next_indirect_addr_write(void) const { return 0; }
 
   virtual bool extract_present_position_from_sync_read(
     const dynamixel_base::comm_t & comm, const std::string & group_name,

--- a/rt_manipulators_lib/include/dynamixel_base.hpp
+++ b/rt_manipulators_lib/include/dynamixel_base.hpp
@@ -96,6 +96,18 @@ class DynamixelBase {
   virtual bool extract_present_position_from_sync_read(
     const dynamixel_base::comm_t & comm, const std::string & group_name,
     double & position_rad) { return false; }
+  virtual bool extract_present_velocity_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & velocity_rps) { return false; }
+  virtual bool extract_present_current_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & current_ampere) { return false; }
+  virtual bool extract_present_input_voltage_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & voltage_volt) { return false; }
+  virtual bool extract_present_temperature_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    int & temperature_deg) { return false; }
 
  protected:
   uint8_t id_;

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -16,6 +16,7 @@
 #define RT_MANIPULATORS_LIB_INCLUDE_DYNAMIXEL_XM_HPP_
 
 #include <string>
+#include <vector>
 
 #include "dynamixel_base.hpp"
 
@@ -95,6 +96,13 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   bool extract_present_temperature_from_sync_read(
     const dynamixel_base::comm_t & comm, const std::string & group_name,
     int & temperature_deg);
+
+  void push_back_position_for_sync_write(
+    const double position_rad, std::vector<uint8_t> & write_data);
+  void push_back_velocity_for_sync_write(
+    const double velocity_rps, std::vector<uint8_t> & write_data);
+  void push_back_current_for_sync_write(
+    const double current_ampere, std::vector<uint8_t> & write_data);
 
  protected:
   int HOME_POSITION_;

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -52,8 +52,34 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   unsigned int from_velocity_rps(const double velocity_rps);
   unsigned int from_current_ampere(const double current_ampere);
 
- private:
+  bool auto_set_indirect_address_of_present_position(const dynamixel_base::comm_t & comm);
+  bool auto_set_indirect_address_of_present_velocity(const dynamixel_base::comm_t & comm);
+  bool auto_set_indirect_address_of_present_current(const dynamixel_base::comm_t & comm);
+  bool auto_set_indirect_address_of_present_input_voltage(const dynamixel_base::comm_t & comm);
+  bool auto_set_indirect_address_of_present_temperature(const dynamixel_base::comm_t & comm);
+
+  unsigned int indirect_addr_of_present_position(void);
+  unsigned int indirect_addr_of_present_velocity(void);
+  unsigned int indirect_addr_of_present_current(void);
+  unsigned int indirect_addr_of_present_input_voltage(void);
+  unsigned int indirect_addr_of_present_temperature(void);
+
+  unsigned int start_address_for_indirect_read(void);
+  unsigned int length_of_indirect_data_read(void);
+
+ protected:
   int HOME_POSITION_;
+  unsigned int total_length_of_indirect_addr_read_;
+  uint16_t indirect_addr_of_present_position_;
+  uint16_t indirect_addr_of_present_velocity_;
+  uint16_t indirect_addr_of_present_current_;
+  uint16_t indirect_addr_of_present_input_voltage_;
+  uint16_t indirect_addr_of_present_temperature_;
+
+  bool set_indirect_address_read(
+    const dynamixel_base::comm_t & comm, const uint16_t addr, const uint16_t len,
+    uint16_t & indirect_addr);
+  unsigned int next_indirect_addr_read(void) const;
 };
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -59,16 +59,26 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   bool auto_set_indirect_address_of_present_current(const dynamixel_base::comm_t & comm);
   bool auto_set_indirect_address_of_present_input_voltage(const dynamixel_base::comm_t & comm);
   bool auto_set_indirect_address_of_present_temperature(const dynamixel_base::comm_t & comm);
+  bool auto_set_indirect_address_of_goal_position(const dynamixel_base::comm_t & comm);
+  bool auto_set_indirect_address_of_goal_velocity(const dynamixel_base::comm_t & comm);
+  bool auto_set_indirect_address_of_goal_current(const dynamixel_base::comm_t & comm);
 
   unsigned int indirect_addr_of_present_position(void);
   unsigned int indirect_addr_of_present_velocity(void);
   unsigned int indirect_addr_of_present_current(void);
   unsigned int indirect_addr_of_present_input_voltage(void);
   unsigned int indirect_addr_of_present_temperature(void);
+  unsigned int indirect_addr_of_goal_position(void);
+  unsigned int indirect_addr_of_goal_velocity(void);
+  unsigned int indirect_addr_of_goal_current(void);
 
   unsigned int start_address_for_indirect_read(void);
   unsigned int length_of_indirect_data_read(void);
   unsigned int next_indirect_addr_read(void) const;
+
+  unsigned int start_address_for_indirect_write(void);
+  unsigned int length_of_indirect_data_write(void);
+  unsigned int next_indirect_addr_write(void) const;
 
   bool extract_present_position_from_sync_read(
     const dynamixel_base::comm_t & comm, const std::string & group_name,
@@ -89,13 +99,20 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
  protected:
   int HOME_POSITION_;
   unsigned int total_length_of_indirect_addr_read_;
+  unsigned int total_length_of_indirect_addr_write_;
   uint16_t indirect_addr_of_present_position_;
   uint16_t indirect_addr_of_present_velocity_;
   uint16_t indirect_addr_of_present_current_;
   uint16_t indirect_addr_of_present_input_voltage_;
   uint16_t indirect_addr_of_present_temperature_;
+  uint16_t indirect_addr_of_goal_position_;
+  uint16_t indirect_addr_of_goal_velocity_;
+  uint16_t indirect_addr_of_goal_current_;
 
   bool set_indirect_address_read(
+    const dynamixel_base::comm_t & comm, const uint16_t addr, const uint16_t len,
+    uint16_t & indirect_addr);
+  bool set_indirect_address_write(
     const dynamixel_base::comm_t & comm, const uint16_t addr, const uint16_t len,
     uint16_t & indirect_addr);
 };

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -15,6 +15,8 @@
 #ifndef RT_MANIPULATORS_LIB_INCLUDE_DYNAMIXEL_XM_HPP_
 #define RT_MANIPULATORS_LIB_INCLUDE_DYNAMIXEL_XM_HPP_
 
+#include <string>
+
 #include "dynamixel_base.hpp"
 
 namespace dynamixel_xm {
@@ -66,6 +68,11 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
 
   unsigned int start_address_for_indirect_read(void);
   unsigned int length_of_indirect_data_read(void);
+  unsigned int next_indirect_addr_read(void) const;
+
+  bool extract_present_position_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & position_rad);
 
  protected:
   int HOME_POSITION_;
@@ -79,7 +86,6 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   bool set_indirect_address_read(
     const dynamixel_base::comm_t & comm, const uint16_t addr, const uint16_t len,
     uint16_t & indirect_addr);
-  unsigned int next_indirect_addr_read(void) const;
 };
 
 }  // namespace dynamixel_xm

--- a/rt_manipulators_lib/include/dynamixel_xm.hpp
+++ b/rt_manipulators_lib/include/dynamixel_xm.hpp
@@ -73,6 +73,18 @@ class DynamixelXM : public dynamixel_base::DynamixelBase  {
   bool extract_present_position_from_sync_read(
     const dynamixel_base::comm_t & comm, const std::string & group_name,
     double & position_rad);
+  bool extract_present_velocity_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & velocity_rps);
+  bool extract_present_current_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & current_ampere);
+  bool extract_present_input_voltage_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & voltage_volt);
+  bool extract_present_temperature_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    int & temperature_deg);
 
  protected:
   int HOME_POSITION_;

--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -86,9 +86,6 @@ class Hardware {
                                        const uint16_t i);
 
  protected:
-  bool write_word_data_to_group(const std::string& group_name, const uint16_t address,
-                                const uint16_t write_data);
-
   std::shared_ptr<hardware_communicator::Communicator> comm_;
 
  private:
@@ -97,8 +94,6 @@ class Hardware {
   bool limit_goal_current_by_present_position(const std::string& group_name);
   bool create_sync_read_group(const std::string& group_name);
   bool create_sync_write_group(const std::string& group_name);
-  bool set_indirect_address(const std::string& group_name, const uint16_t addr_indirect_start,
-                            const uint16_t addr_target, const uint16_t len_target);
   void read_write_thread(const std::vector<std::string>& group_names,
                          const std::chrono::milliseconds& update_cycle_ms);
 

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -382,6 +382,31 @@ bool DynamixelXM::extract_present_temperature_from_sync_read(
   return true;
 }
 
+void DynamixelXM::push_back_position_for_sync_write(
+    const double position_rad, std::vector<uint8_t> & write_data) {
+  uint32_t dxl_position = from_position_radian(position_rad);
+  write_data.push_back(DXL_LOBYTE(DXL_LOWORD(dxl_position)));
+  write_data.push_back(DXL_HIBYTE(DXL_LOWORD(dxl_position)));
+  write_data.push_back(DXL_LOBYTE(DXL_HIWORD(dxl_position)));
+  write_data.push_back(DXL_HIBYTE(DXL_HIWORD(dxl_position)));
+}
+
+void DynamixelXM::push_back_velocity_for_sync_write(
+    const double velocity_rps, std::vector<uint8_t> & write_data) {
+  uint32_t dxl_velocity = from_velocity_rps(velocity_rps);
+  write_data.push_back(DXL_LOBYTE(DXL_LOWORD(dxl_velocity)));
+  write_data.push_back(DXL_HIBYTE(DXL_LOWORD(dxl_velocity)));
+  write_data.push_back(DXL_LOBYTE(DXL_HIWORD(dxl_velocity)));
+  write_data.push_back(DXL_HIBYTE(DXL_HIWORD(dxl_velocity)));
+}
+
+void DynamixelXM::push_back_current_for_sync_write(
+    const double current_ampere, std::vector<uint8_t> & write_data) {
+  uint16_t dxl_current = from_current_ampere(current_ampere);
+  write_data.push_back(DXL_LOBYTE(dxl_current));
+  write_data.push_back(DXL_HIBYTE(dxl_current));
+}
+
 bool DynamixelXM::set_indirect_address_read(
     const dynamixel_base::comm_t & comm, const uint16_t addr, const uint16_t len,
     uint16_t & indirect_addr) {

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -29,8 +29,11 @@ const uint16_t ADDR_VELOCITY_P_GAIN = 78;
 const uint16_t ADDR_POSITION_D_GAIN = 80;
 const uint16_t ADDR_POSITION_I_GAIN = 82;
 const uint16_t ADDR_POSITION_P_GAIN = 84;
+const uint16_t ADDR_GOAL_CURRENT = 102;
+const uint16_t ADDR_GOAL_VELOCITY = 104;
 const uint16_t ADDR_PROFILE_ACCELERATION = 108;
 const uint16_t ADDR_PROFILE_VELOCITY = 112;
+const uint16_t ADDR_GOAL_POSITION = 116;
 const uint16_t ADDR_PRESENT_CURRENT = 126;
 const uint16_t ADDR_PRESENT_VELOCITY = 128;
 const uint16_t ADDR_PRESENT_POSITION = 132;
@@ -51,6 +54,9 @@ const uint16_t LEN_PRESENT_VELOCITY = 4;
 const uint16_t LEN_PRESENT_POSITION = 4;
 const uint16_t LEN_PRESENT_VOLTAGE = 2;
 const uint16_t LEN_PRESENT_TEMPERATURE = 1;
+const uint16_t LEN_GOAL_CURRENT = 2;
+const uint16_t LEN_GOAL_VELOCITY = 4;
+const uint16_t LEN_GOAL_POSITION = 4;
 const uint16_t LEN_INDIRECT_ADDRESS = 2;
 
 const double TO_ACCELERATION_REV_PER_MM = 214.577;
@@ -71,9 +77,11 @@ const double TO_DXL_CURRENT = 1.0 / TO_CURRENT_AMPERE;
 
 DynamixelXM::DynamixelXM(const uint8_t id, const int home_position)
   : dynamixel_base::DynamixelBase(id), HOME_POSITION_(home_position),
-    total_length_of_indirect_addr_read_(0), indirect_addr_of_present_position_(0),
-    indirect_addr_of_present_velocity_(0), indirect_addr_of_present_current_(0),
-    indirect_addr_of_present_input_voltage_(0), indirect_addr_of_present_temperature_(0) {
+    total_length_of_indirect_addr_read_(0), total_length_of_indirect_addr_write_(0),
+    indirect_addr_of_present_position_(0), indirect_addr_of_present_velocity_(0),
+    indirect_addr_of_present_current_(0), indirect_addr_of_present_input_voltage_(0),
+    indirect_addr_of_present_temperature_(0), indirect_addr_of_goal_position_(0),
+    indirect_addr_of_goal_velocity_(0), indirect_addr_of_goal_current_(0) {
   name_ = "XM";
 }
 
@@ -238,6 +246,24 @@ bool DynamixelXM::auto_set_indirect_address_of_present_temperature(
     comm, ADDR_PRESENT_TEMPERATURE, LEN_PRESENT_TEMPERATURE, indirect_addr_of_present_temperature_);
 }
 
+bool DynamixelXM::auto_set_indirect_address_of_goal_position(
+  const dynamixel_base::comm_t & comm) {
+  return set_indirect_address_write(
+    comm, ADDR_GOAL_POSITION, LEN_GOAL_POSITION, indirect_addr_of_goal_position_);
+}
+
+bool DynamixelXM::auto_set_indirect_address_of_goal_velocity(
+  const dynamixel_base::comm_t & comm) {
+  return set_indirect_address_write(
+    comm, ADDR_GOAL_VELOCITY, LEN_GOAL_VELOCITY, indirect_addr_of_goal_velocity_);
+}
+
+bool DynamixelXM::auto_set_indirect_address_of_goal_current(
+  const dynamixel_base::comm_t & comm) {
+  return set_indirect_address_write(
+    comm, ADDR_GOAL_CURRENT, LEN_GOAL_CURRENT, indirect_addr_of_goal_current_);
+}
+
 unsigned int DynamixelXM::indirect_addr_of_present_position(void) {
   return indirect_addr_of_present_position_;
 }
@@ -258,6 +284,18 @@ unsigned int DynamixelXM::indirect_addr_of_present_temperature(void) {
   return indirect_addr_of_present_temperature_;
 }
 
+unsigned int DynamixelXM::indirect_addr_of_goal_position(void) {
+  return indirect_addr_of_goal_position_;
+}
+
+unsigned int DynamixelXM::indirect_addr_of_goal_velocity(void) {
+  return indirect_addr_of_goal_velocity_;
+}
+
+unsigned int DynamixelXM::indirect_addr_of_goal_current(void) {
+  return indirect_addr_of_goal_current_;
+}
+
 unsigned int DynamixelXM::start_address_for_indirect_read(void) {
   return ADDR_START_INDIRECT_DATA_READ;
 }
@@ -269,6 +307,19 @@ unsigned int DynamixelXM::length_of_indirect_data_read(void) {
 unsigned int DynamixelXM::next_indirect_addr_read(void) const {
   return ADDR_START_INDIRECT_ADDR_READ +
     LEN_INDIRECT_ADDRESS * total_length_of_indirect_addr_read_;
+}
+
+unsigned int DynamixelXM::start_address_for_indirect_write(void) {
+  return ADDR_START_INDIRECT_DATA_WRITE;
+}
+
+unsigned int DynamixelXM::length_of_indirect_data_write(void) {
+  return total_length_of_indirect_addr_write_;
+}
+
+unsigned int DynamixelXM::next_indirect_addr_write(void) const {
+  return ADDR_START_INDIRECT_ADDR_WRITE +
+    LEN_INDIRECT_ADDRESS * total_length_of_indirect_addr_write_;
 }
 
 bool DynamixelXM::extract_present_position_from_sync_read(
@@ -347,6 +398,25 @@ bool DynamixelXM::set_indirect_address_read(
   indirect_addr = ADDR_START_INDIRECT_DATA_READ
     + total_length_of_indirect_addr_read_;
   total_length_of_indirect_addr_read_ += len;
+  return retval;
+}
+
+bool DynamixelXM::set_indirect_address_write(
+    const dynamixel_base::comm_t & comm, const uint16_t addr, const uint16_t len,
+    uint16_t & indirect_addr) {
+  bool retval = true;
+  for (int i = 0; i < len; i++) {
+    uint16_t target_indirect_address = next_indirect_addr_write() + LEN_INDIRECT_ADDRESS * i;
+    uint16_t target_data_address = addr + i;
+    if (!comm->write_word_data(
+      id_, target_indirect_address, target_data_address)) {
+      retval = false;
+    }
+  }
+  // テストしやすくするため、write_word_dataに失敗しても変数を更新する
+  indirect_addr = ADDR_START_INDIRECT_DATA_WRITE
+    + total_length_of_indirect_addr_write_;
+  total_length_of_indirect_addr_write_ += len;
   return retval;
 }
 

--- a/rt_manipulators_lib/src/dynamixel_xm.cpp
+++ b/rt_manipulators_lib/src/dynamixel_xm.cpp
@@ -276,10 +276,58 @@ bool DynamixelXM::extract_present_position_from_sync_read(
     double & position_rad) {
   uint32_t data = 0;
   if (!comm->get_sync_read_data(
-    group_name, id_, indirect_addr_of_present_position_, LEN_PRESENT_POSITION, data)) {
+    group_name, id_, indirect_addr_of_present_position(), LEN_PRESENT_POSITION, data)) {
     return false;
   }
   position_rad = to_position_radian(static_cast<int32_t>(data));
+  return true;
+}
+
+bool DynamixelXM::extract_present_velocity_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & velocity_rps) {
+  uint32_t data = 0;
+  if (!comm->get_sync_read_data(
+    group_name, id_, indirect_addr_of_present_velocity(), LEN_PRESENT_VELOCITY, data)) {
+    return false;
+  }
+  velocity_rps = to_velocity_rps(static_cast<int32_t>(data));
+  return true;
+}
+
+bool DynamixelXM::extract_present_current_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & current_ampere) {
+  uint32_t data = 0;
+  if (!comm->get_sync_read_data(
+    group_name, id_, indirect_addr_of_present_current(), LEN_PRESENT_CURRENT, data)) {
+    return false;
+  }
+  current_ampere = to_current_ampere(static_cast<int16_t>(data));
+  return true;
+}
+
+bool DynamixelXM::extract_present_input_voltage_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    double & voltage_volt) {
+  uint32_t data = 0;
+  if (!comm->get_sync_read_data(
+    group_name, id_, indirect_addr_of_present_input_voltage(), LEN_PRESENT_VOLTAGE, data)) {
+    return false;
+  }
+  voltage_volt = to_voltage_volt(static_cast<int16_t>(data));
+  return true;
+}
+
+bool DynamixelXM::extract_present_temperature_from_sync_read(
+    const dynamixel_base::comm_t & comm, const std::string & group_name,
+    int & temperature_deg) {
+  uint32_t data = 0;
+  if (!comm->get_sync_read_data(
+    group_name, id_, indirect_addr_of_present_temperature(), LEN_PRESENT_TEMPERATURE, data)) {
+    return false;
+  }
+  temperature_deg = static_cast<int8_t>(data);
   return true;
 }
 

--- a/rt_manipulators_lib/src/hardware.cpp
+++ b/rt_manipulators_lib/src/hardware.cpp
@@ -21,34 +21,6 @@
 
 namespace rt_manipulators_cpp {
 
-// Ref: https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/
-// Ref: https://emanual.robotis.com/docs/en/dxl/x/xm540-w270/
-// Ref: https://emanual.robotis.com/docs/en/dxl/x/xm540-w150/
-
-// Dynamixel XM Series address table
-const uint16_t ADDR_GOAL_CURRENT = 102;
-const uint16_t ADDR_GOAL_VELOCITY = 104;
-const uint16_t ADDR_GOAL_POSITION = 116;
-const uint16_t ADDR_PRESENT_CURRENT = 126;
-const uint16_t ADDR_PRESENT_VELOCITY = 128;
-const uint16_t ADDR_PRESENT_POSITION = 132;
-const uint16_t ADDR_PRESENT_VOLTAGE = 144;
-const uint16_t ADDR_PRESENT_TEMPERATURE = 146;
-const uint16_t ADDR_INDIRECT_ADDRESS_1 = 168;
-const uint16_t ADDR_INDIRECT_DATA_1 = 224;
-const uint16_t ADDR_INDIRECT_ADDRESS_29 = 578;
-const uint16_t ADDR_INDIRECT_DATA_29 = 634;
-
-const uint16_t LEN_GOAL_CURRENT = 2;
-const uint16_t LEN_GOAL_VELOCITY = 4;
-const uint16_t LEN_GOAL_POSITION = 4;
-const uint16_t LEN_PRESENT_CURRENT = 2;
-const uint16_t LEN_PRESENT_VELOCITY = 4;
-const uint16_t LEN_PRESENT_POSITION = 4;
-const uint16_t LEN_PRESENT_VOLTAGE = 2;
-const uint16_t LEN_PRESENT_TEMPERATURE = 1;
-const uint16_t LEN_INDIRECT_ADDRESS = 2;
-
 Hardware::Hardware(const std::string device_name) :
   thread_enable_(false) {
   comm_ = std::make_shared<hardware_communicator::Communicator>(device_name);
@@ -659,23 +631,6 @@ bool Hardware::write_velocity_pi_gain_to_group(const std::string& group_name, co
   return retval;
 }
 
-bool Hardware::write_word_data_to_group(const std::string& group_name, const uint16_t address,
-                                        const uint16_t write_data) {
-  if (!joints_.has_group(group_name)) {
-    std::cerr << group_name << "はjoint_groupsに存在しません." << std::endl;
-    return false;
-  }
-
-  bool retval = true;
-  for (const auto & joint_name : joints_.group(group_name)->joint_names()) {
-    auto id = joints_.joint(joint_name)->id();
-    if (!comm_->write_word_data(id, address, write_data)) {
-      retval = false;
-    }
-  }
-  return retval;
-}
-
 bool Hardware::write_operating_mode(const std::string& group_name) {
   // サーボモータから動作モードを読み取り、
   // コンフィグファイルと一致しない場合、動作モードを書き込む
@@ -883,26 +838,6 @@ bool Hardware::create_sync_write_group(const std::string& group_name) {
     }
   }
 
-  return true;
-}
-
-bool Hardware::set_indirect_address(const std::string& group_name,
-                                    const uint16_t addr_indirect_start, const uint16_t addr_target,
-                                    const uint16_t len_target) {
-  // 指定されたグループのサーボモータのインダイレクトアドレスに、指定されたデータのアドレスを設定する
-
-  bool retval = true;
-  for (int i = 0; i < len_target; i++) {
-    uint16_t target_indirect_address = addr_indirect_start + LEN_INDIRECT_ADDRESS * i;
-    uint16_t target_data_address = addr_target + i;
-
-    if (!write_word_data_to_group(group_name, target_indirect_address, target_data_address)) {
-      std::cerr << "インダイレクトアドレス:" << std::to_string(target_indirect_address);
-      std::cerr << "にターゲットデータアドレス:" << std::to_string(target_data_address);
-      std::cerr << "を書き込めませんでした." << std::endl;
-      return false;
-    }
-  }
   return true;
 }
 

--- a/rt_manipulators_lib/src/hardware_communicator.cpp
+++ b/rt_manipulators_lib/src/hardware_communicator.cpp
@@ -123,6 +123,12 @@ bool Communicator::send_sync_write_packet(const group_name_t & group_name) {
 bool Communicator::get_sync_read_data(
   const group_name_t & group_name, const dxl_id_t id, const dxl_address_t & address,
   const dxl_data_length_t & length, dxl_double_word_t & read_data) {
+
+  if (!has_sync_read_group(group_name)) {
+    std::cerr << group_name << "にはsync_read_groupが設定されていません." << std::endl;
+    return false;
+  }
+
   if (!sync_read_group(group_name)->isAvailable(id, address, length)) {
     std::cerr << "id: " << std::to_string(id);
     std::cerr << ", addr: " << std::to_string(address);

--- a/rt_manipulators_lib/src/hardware_communicator.cpp
+++ b/rt_manipulators_lib/src/hardware_communicator.cpp
@@ -123,7 +123,6 @@ bool Communicator::send_sync_write_packet(const group_name_t & group_name) {
 bool Communicator::get_sync_read_data(
   const group_name_t & group_name, const dxl_id_t id, const dxl_address_t & address,
   const dxl_data_length_t & length, dxl_double_word_t & read_data) {
-
   if (!has_sync_read_group(group_name)) {
     std::cerr << group_name << "にはsync_read_groupが設定されていません." << std::endl;
     return false;

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -162,3 +162,35 @@ TEST_F(XMTestFixture, from_current_ampere) {
   EXPECT_EQ(dxl->from_current_ampere(2.691), 1000);
   EXPECT_EQ(dxl->from_current_ampere(-2.691), 0xFFFFFC18);  // -1000
 }
+
+TEST_F(XMTestFixture, auto_set_indirect_address_of_present_position) {
+  ASSERT_FALSE(dxl->auto_set_indirect_address_of_present_position(comm));
+}
+
+TEST_F(XMTestFixture, set_indirect_addresses) {
+  EXPECT_EQ(dxl->start_address_for_indirect_read(), 224);
+  EXPECT_EQ(dxl->length_of_indirect_data_read(), 0);
+  EXPECT_EQ(dxl->indirect_addr_of_present_position(), 0);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_position(comm));
+  // indirect_dataの開始位置は変わらないことを期待
+  EXPECT_EQ(dxl->start_address_for_indirect_read(), 224);
+  EXPECT_EQ(dxl->length_of_indirect_data_read(), 4);
+  EXPECT_EQ(dxl->indirect_addr_of_present_position(), 224);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_velocity(comm));
+  EXPECT_EQ(dxl->length_of_indirect_data_read(), 8);
+  EXPECT_EQ(dxl->indirect_addr_of_present_velocity(), 228);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_current(comm));
+  EXPECT_EQ(dxl->length_of_indirect_data_read(), 10);
+  EXPECT_EQ(dxl->indirect_addr_of_present_current(), 232);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_input_voltage(comm));
+  EXPECT_EQ(dxl->length_of_indirect_data_read(), 12);
+  EXPECT_EQ(dxl->indirect_addr_of_present_input_voltage(), 234);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_temperature(comm));
+  EXPECT_EQ(dxl->length_of_indirect_data_read(), 13);
+  EXPECT_EQ(dxl->indirect_addr_of_present_temperature(), 236);
+}

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -201,3 +201,27 @@ TEST_F(XMTestFixture, extract_present_position_from_sync_read) {
   double position;
   ASSERT_FALSE(dxl->extract_present_position_from_sync_read(comm, group_name, position));
 }
+
+TEST_F(XMTestFixture, extract_present_velocity_from_sync_read) {
+  std::string group_name = "test";
+  double velocity;
+  ASSERT_FALSE(dxl->extract_present_velocity_from_sync_read(comm, group_name, velocity));
+}
+
+TEST_F(XMTestFixture, extract_present_current_from_sync_read) {
+  std::string group_name = "test";
+  double current;
+  ASSERT_FALSE(dxl->extract_present_current_from_sync_read(comm, group_name, current));
+}
+
+TEST_F(XMTestFixture, extract_present_input_voltage_from_sync_read) {
+  std::string group_name = "test";
+  double voltage;
+  ASSERT_FALSE(dxl->extract_present_input_voltage_from_sync_read(comm, group_name, voltage));
+}
+
+TEST_F(XMTestFixture, extract_present_temperature_from_sync_read) {
+  std::string group_name = "test";
+  int temp;
+  ASSERT_FALSE(dxl->extract_present_temperature_from_sync_read(comm, group_name, temp));
+}

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -196,6 +196,29 @@ TEST_F(XMTestFixture, set_indirect_addresses_read) {
   EXPECT_EQ(dxl->indirect_addr_of_present_temperature(), 236);
 }
 
+TEST_F(XMTestFixture, set_indirect_addresses_write) {
+  EXPECT_EQ(dxl->start_address_for_indirect_write(), 634);
+  EXPECT_EQ(dxl->length_of_indirect_data_write(), 0);
+  EXPECT_EQ(dxl->next_indirect_addr_write(), 578);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_goal_position(comm));
+  // indirect_dataの開始位置は変わらないことを期待
+  EXPECT_EQ(dxl->start_address_for_indirect_write(), 634);
+  EXPECT_EQ(dxl->length_of_indirect_data_write(), 4);
+  EXPECT_EQ(dxl->next_indirect_addr_write(), 586);
+  EXPECT_EQ(dxl->indirect_addr_of_goal_position(), 634);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_goal_velocity(comm));
+  EXPECT_EQ(dxl->length_of_indirect_data_write(), 8);
+  EXPECT_EQ(dxl->next_indirect_addr_write(), 594);
+  EXPECT_EQ(dxl->indirect_addr_of_goal_velocity(), 638);
+
+  EXPECT_FALSE(dxl->auto_set_indirect_address_of_goal_current(comm));
+  EXPECT_EQ(dxl->length_of_indirect_data_write(), 10);
+  EXPECT_EQ(dxl->next_indirect_addr_write(), 598);
+  EXPECT_EQ(dxl->indirect_addr_of_goal_current(), 642);
+}
+
 TEST_F(XMTestFixture, extract_present_position_from_sync_read) {
   std::string group_name = "test";
   double position;

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -248,3 +248,59 @@ TEST_F(XMTestFixture, extract_present_temperature_from_sync_read) {
   int temp;
   ASSERT_FALSE(dxl->extract_present_temperature_from_sync_read(comm, group_name, temp));
 }
+
+TEST_F(XMTestFixture, push_back_position_for_sync_write) {
+  std::vector<uint8_t> test_data;
+  dxl->push_back_position_for_sync_write(M_PI_2, test_data);
+  ASSERT_EQ(test_data.size(), 4);
+  // from_position_radian(M_PI_2) = 2048 + 1024 (0x0000 0C00)がセットされる
+  EXPECT_EQ(test_data.at(0), 0x00);
+  EXPECT_EQ(test_data.at(1), 0x0C);
+  EXPECT_EQ(test_data.at(2), 0x00);
+  EXPECT_EQ(test_data.at(3), 0x00);
+
+  test_data.clear();
+  dxl->push_back_position_for_sync_write(-M_PI_2, test_data);
+  ASSERT_EQ(test_data.size(), 4);
+  // from_position_radian(-M_PI_2) = 2048 - 1024 (0x0000 0400)がセットされる
+  EXPECT_EQ(test_data.at(0), 0x00);
+  EXPECT_EQ(test_data.at(1), 0x04);
+  EXPECT_EQ(test_data.at(2), 0x00);
+  EXPECT_EQ(test_data.at(3), 0x00);
+}
+
+TEST_F(XMTestFixture, push_back_velocity_for_sync_write) {
+  std::vector<uint8_t> test_data;
+  dxl->push_back_velocity_for_sync_write(0.239809, test_data);
+  ASSERT_EQ(test_data.size(), 4);
+  // from_velocity_rps(0.239809) = 10 (0x0000 000A)がセットされる
+  EXPECT_EQ(test_data.at(0), 0x0A);
+  EXPECT_EQ(test_data.at(1), 0x00);
+  EXPECT_EQ(test_data.at(2), 0x00);
+  EXPECT_EQ(test_data.at(3), 0x00);
+
+  test_data.clear();
+  dxl->push_back_velocity_for_sync_write(-0.239809, test_data);
+  ASSERT_EQ(test_data.size(), 4);
+  // from_velocity_rps(-0.239809) = -10 (0xFFFF FFF6)がセットされる
+  EXPECT_EQ(test_data.at(0), 0xF6);
+  EXPECT_EQ(test_data.at(1), 0xFF);
+  EXPECT_EQ(test_data.at(2), 0xFF);
+  EXPECT_EQ(test_data.at(3), 0xFF);
+}
+
+TEST_F(XMTestFixture, push_back_current_for_sync_write) {
+  std::vector<uint8_t> test_data;
+  dxl->push_back_current_for_sync_write(2.691, test_data);
+  ASSERT_EQ(test_data.size(), 2);
+  // from_current_ampere(2.691) = 1000 (0x03E8)がセットされる
+  EXPECT_EQ(test_data.at(0), 0xE8);
+  EXPECT_EQ(test_data.at(1), 0x03);
+
+  test_data.clear();
+  dxl->push_back_current_for_sync_write(-2.691, test_data);
+  ASSERT_EQ(test_data.size(), 2);
+  // from_current_ampere(-2.691) = -1000 (0xFC18)がセットされる
+  EXPECT_EQ(test_data.at(0), 0x18);
+  EXPECT_EQ(test_data.at(1), 0xFC);
+}

--- a/rt_manipulators_lib/test/test_dynamixel_xm.cpp
+++ b/rt_manipulators_lib/test/test_dynamixel_xm.cpp
@@ -163,34 +163,41 @@ TEST_F(XMTestFixture, from_current_ampere) {
   EXPECT_EQ(dxl->from_current_ampere(-2.691), 0xFFFFFC18);  // -1000
 }
 
-TEST_F(XMTestFixture, auto_set_indirect_address_of_present_position) {
-  ASSERT_FALSE(dxl->auto_set_indirect_address_of_present_position(comm));
-}
-
-TEST_F(XMTestFixture, set_indirect_addresses) {
+TEST_F(XMTestFixture, set_indirect_addresses_read) {
   EXPECT_EQ(dxl->start_address_for_indirect_read(), 224);
   EXPECT_EQ(dxl->length_of_indirect_data_read(), 0);
-  EXPECT_EQ(dxl->indirect_addr_of_present_position(), 0);
+  EXPECT_EQ(dxl->next_indirect_addr_read(), 168);
 
   EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_position(comm));
   // indirect_dataの開始位置は変わらないことを期待
   EXPECT_EQ(dxl->start_address_for_indirect_read(), 224);
   EXPECT_EQ(dxl->length_of_indirect_data_read(), 4);
+  EXPECT_EQ(dxl->next_indirect_addr_read(), 176);
   EXPECT_EQ(dxl->indirect_addr_of_present_position(), 224);
 
   EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_velocity(comm));
   EXPECT_EQ(dxl->length_of_indirect_data_read(), 8);
+  EXPECT_EQ(dxl->next_indirect_addr_read(), 184);
   EXPECT_EQ(dxl->indirect_addr_of_present_velocity(), 228);
 
   EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_current(comm));
   EXPECT_EQ(dxl->length_of_indirect_data_read(), 10);
+  EXPECT_EQ(dxl->next_indirect_addr_read(), 188);
   EXPECT_EQ(dxl->indirect_addr_of_present_current(), 232);
 
   EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_input_voltage(comm));
   EXPECT_EQ(dxl->length_of_indirect_data_read(), 12);
+  EXPECT_EQ(dxl->next_indirect_addr_read(), 192);
   EXPECT_EQ(dxl->indirect_addr_of_present_input_voltage(), 234);
 
   EXPECT_FALSE(dxl->auto_set_indirect_address_of_present_temperature(comm));
   EXPECT_EQ(dxl->length_of_indirect_data_read(), 13);
+  EXPECT_EQ(dxl->next_indirect_addr_read(), 194);
   EXPECT_EQ(dxl->indirect_addr_of_present_temperature(), 236);
+}
+
+TEST_F(XMTestFixture, extract_present_position_from_sync_read) {
+  std::string group_name = "test";
+  double position;
+  ASSERT_FALSE(dxl->extract_present_position_from_sync_read(comm, group_name, position));
 }


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#18 の続きです。
sync_read, sync_write関連の関数をdynamixelクラスへ移植します。
この変更により、hardwareクラスからdynamixel特有の情報（アドレスやデータ長など）をすべて取り除けます。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

CRANE-X7実機で下記のサンプルを実行し、実行結果に変化が無いことを確認しています。

- x7_read_present_values : 特に、速度、電流値が異常値を示していないことを確認
- x7_write_position
- x7_write_velocity
- x7_write_current

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
