### PR TITLE
Add an unittest environment for hardware class.

### DIFF
--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 #include "joint.hpp"
@@ -84,6 +85,28 @@ class Hardware {
   bool write_velocity_pi_gain(const std::string& joint_name, const uint16_t p, const uint16_t i);
   bool write_velocity_pi_gain_to_group(const std::string& group_name, const uint16_t p,
                                        const uint16_t i);
+
+  template <typename IdentifyT, typename DataT>
+  bool write_data(const IdentifyT & identify, const uint16_t & addr, const DataT & data)
+  {
+    if (!joints_.has_joint(identify)) {
+      std::cerr << "Joint: " << identify << " is not registered." << std::endl;
+      return false;
+    }
+
+    if (std::is_same<DataT, uint8_t>::value) {
+      return comm_->write_byte_data(joints_.joint(identify)->id(), addr, data);
+    }
+    if (std::is_same<DataT, uint16_t>::value) {
+      return comm_->write_word_data(joints_.joint(identify)->id(), addr, data);
+    }
+    if (std::is_same<DataT, uint32_t>::value) {
+      return comm_->write_double_word_data(joints_.joint(identify)->id(), addr, data);
+    }
+
+    return false;
+  }
+
 
  protected:
   std::shared_ptr<hardware_communicator::Communicator> comm_;

--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -20,7 +20,6 @@
 #include <memory>
 #include <string>
 #include <thread>
-#include <type_traits>
 #include <vector>
 
 #include "joint.hpp"

--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -35,6 +35,7 @@ using JointName = std::string;
 class Hardware {
  public:
   explicit Hardware(const std::string device_name);
+  explicit Hardware(std::unique_ptr<hardware_communicator::Communicator> comm);
   ~Hardware();
   bool load_config_file(const std::string& config_yaml);
   bool connect(const int baudrate = 3000000);

--- a/rt_manipulators_lib/include/hardware.hpp
+++ b/rt_manipulators_lib/include/hardware.hpp
@@ -87,28 +87,6 @@ class Hardware {
   bool write_velocity_pi_gain_to_group(const std::string& group_name, const uint16_t p,
                                        const uint16_t i);
 
-  template <typename IdentifyT, typename DataT>
-  bool write_data(const IdentifyT & identify, const uint16_t & addr, const DataT & data)
-  {
-    if (!joints_.has_joint(identify)) {
-      std::cerr << "Joint: " << identify << " is not registered." << std::endl;
-      return false;
-    }
-
-    if (std::is_same<DataT, uint8_t>::value) {
-      return comm_->write_byte_data(joints_.joint(identify)->id(), addr, data);
-    }
-    if (std::is_same<DataT, uint16_t>::value) {
-      return comm_->write_word_data(joints_.joint(identify)->id(), addr, data);
-    }
-    if (std::is_same<DataT, uint32_t>::value) {
-      return comm_->write_double_word_data(joints_.joint(identify)->id(), addr, data);
-    }
-
-    return false;
-  }
-
-
  protected:
   std::shared_ptr<hardware_communicator::Communicator> comm_;
 

--- a/rt_manipulators_lib/include/hardware_communicator.hpp
+++ b/rt_manipulators_lib/include/hardware_communicator.hpp
@@ -40,9 +40,9 @@ class Communicator{
  public:
   explicit Communicator(const std::string device_name);
   virtual ~Communicator();
-  bool is_connected();
+  virtual bool is_connected();
   virtual bool connect(const int baudrate = 3000000);
-  void disconnect();
+  virtual void disconnect();
   virtual void make_sync_read_group(const group_name_t & group_name, const dxl_address_t & start_address,
                               const dxl_data_length_t & data_length);
   virtual void make_sync_write_group(const group_name_t & group_name, const dxl_address_t & start_address,
@@ -50,12 +50,12 @@ class Communicator{
   virtual bool append_id_to_sync_read_group(const group_name_t & group_name, const dxl_id_t & id);
   virtual bool append_id_to_sync_write_group(const group_name_t & group_name, const dxl_id_t & id,
                                      std::vector<dxl_byte_t> & init_data);
-  bool send_sync_read_packet(const group_name_t & group_name);
-  bool send_sync_write_packet(const group_name_t & group_name);
-  bool get_sync_read_data(const group_name_t & group_name, const dxl_id_t id,
+  virtual bool send_sync_read_packet(const group_name_t & group_name);
+  virtual bool send_sync_write_packet(const group_name_t & group_name);
+  virtual bool get_sync_read_data(const group_name_t & group_name, const dxl_id_t id,
                           const dxl_address_t & address, const dxl_data_length_t & length,
                           dxl_double_word_t & read_data);
-  bool set_sync_write_data(const group_name_t & group_name, const dxl_id_t id,
+  virtual bool set_sync_write_data(const group_name_t & group_name, const dxl_id_t id,
                            std::vector<dxl_byte_t> & write_data);
   virtual bool write_byte_data(const dxl_id_t & id, const dxl_address_t & address,
                        const dxl_byte_t & write_data);

--- a/rt_manipulators_lib/include/hardware_communicator.hpp
+++ b/rt_manipulators_lib/include/hardware_communicator.hpp
@@ -43,10 +43,12 @@ class Communicator{
   virtual bool is_connected();
   virtual bool connect(const int baudrate = 3000000);
   virtual void disconnect();
-  virtual void make_sync_read_group(const group_name_t & group_name, const dxl_address_t & start_address,
-                              const dxl_data_length_t & data_length);
-  virtual void make_sync_write_group(const group_name_t & group_name, const dxl_address_t & start_address,
-                               const dxl_data_length_t & data_length);
+  virtual void make_sync_read_group(
+    const group_name_t & group_name, const dxl_address_t & start_address,
+    const dxl_data_length_t & data_length);
+  virtual void make_sync_write_group(
+    const group_name_t & group_name, const dxl_address_t & start_address,
+    const dxl_data_length_t & data_length);
   virtual bool append_id_to_sync_read_group(const group_name_t & group_name, const dxl_id_t & id);
   virtual bool append_id_to_sync_write_group(const group_name_t & group_name, const dxl_id_t & id,
                                      std::vector<dxl_byte_t> & init_data);
@@ -61,10 +63,13 @@ class Communicator{
                        const dxl_byte_t & write_data);
   virtual bool write_word_data(const dxl_id_t & id, const dxl_address_t & address,
                        const dxl_word_t & write_data);
-  virtual bool write_double_word_data(const dxl_id_t & id, const dxl_address_t & address,
-                              const dxl_double_word_t & write_data);
-  virtual bool read_byte_data(const dxl_id_t & id, const dxl_address_t & address, dxl_byte_t & read_data);
-  virtual bool read_word_data(const dxl_id_t & id, const dxl_address_t & address, dxl_word_t & read_data);
+  virtual bool write_double_word_data(
+    const dxl_id_t & id, const dxl_address_t & address,
+    const dxl_double_word_t & write_data);
+  virtual bool read_byte_data(
+    const dxl_id_t & id, const dxl_address_t & address, dxl_byte_t & read_data);
+  virtual bool read_word_data(
+    const dxl_id_t & id, const dxl_address_t & address, dxl_word_t & read_data);
   virtual bool read_double_word_data(const dxl_id_t & id, const dxl_address_t & address,
                              dxl_double_word_t & read_data);
 

--- a/rt_manipulators_lib/include/hardware_communicator.hpp
+++ b/rt_manipulators_lib/include/hardware_communicator.hpp
@@ -39,33 +39,33 @@ using GroupSyncWrite = dynamixel::GroupSyncWrite;
 class Communicator{
  public:
   explicit Communicator(const std::string device_name);
-  ~Communicator();
-  bool is_connected();
-  bool connect(const int baudrate = 3000000);
-  void disconnect();
-  void make_sync_read_group(const group_name_t & group_name, const dxl_address_t & start_address,
+  virtual ~Communicator();
+  virtual bool is_connected();
+  virtual bool connect(const int baudrate = 3000000);
+  virtual void disconnect();
+  virtual void make_sync_read_group(const group_name_t & group_name, const dxl_address_t & start_address,
                               const dxl_data_length_t & data_length);
-  void make_sync_write_group(const group_name_t & group_name, const dxl_address_t & start_address,
+  virtual void make_sync_write_group(const group_name_t & group_name, const dxl_address_t & start_address,
                                const dxl_data_length_t & data_length);
-  bool append_id_to_sync_read_group(const group_name_t & group_name, const dxl_id_t & id);
-  bool append_id_to_sync_write_group(const group_name_t & group_name, const dxl_id_t & id,
+  virtual bool append_id_to_sync_read_group(const group_name_t & group_name, const dxl_id_t & id);
+  virtual bool append_id_to_sync_write_group(const group_name_t & group_name, const dxl_id_t & id,
                                      std::vector<dxl_byte_t> & init_data);
-  bool send_sync_read_packet(const group_name_t & group_name);
-  bool send_sync_write_packet(const group_name_t & group_name);
-  bool get_sync_read_data(const group_name_t & group_name, const dxl_id_t id,
+  virtual bool send_sync_read_packet(const group_name_t & group_name);
+  virtual bool send_sync_write_packet(const group_name_t & group_name);
+  virtual bool get_sync_read_data(const group_name_t & group_name, const dxl_id_t id,
                           const dxl_address_t & address, const dxl_data_length_t & length,
                           dxl_double_word_t & read_data);
-  bool set_sync_write_data(const group_name_t & group_name, const dxl_id_t id,
+  virtual bool set_sync_write_data(const group_name_t & group_name, const dxl_id_t id,
                            std::vector<dxl_byte_t> & write_data);
-  bool write_byte_data(const dxl_id_t & id, const dxl_address_t & address,
+  virtual bool write_byte_data(const dxl_id_t & id, const dxl_address_t & address,
                        const dxl_byte_t & write_data);
-  bool write_word_data(const dxl_id_t & id, const dxl_address_t & address,
+  virtual bool write_word_data(const dxl_id_t & id, const dxl_address_t & address,
                        const dxl_word_t & write_data);
-  bool write_double_word_data(const dxl_id_t & id, const dxl_address_t & address,
+  virtual bool write_double_word_data(const dxl_id_t & id, const dxl_address_t & address,
                               const dxl_double_word_t & write_data);
-  bool read_byte_data(const dxl_id_t & id, const dxl_address_t & address, dxl_byte_t & read_data);
-  bool read_word_data(const dxl_id_t & id, const dxl_address_t & address, dxl_word_t & read_data);
-  bool read_double_word_data(const dxl_id_t & id, const dxl_address_t & address,
+  virtual bool read_byte_data(const dxl_id_t & id, const dxl_address_t & address, dxl_byte_t & read_data);
+  virtual bool read_word_data(const dxl_id_t & id, const dxl_address_t & address, dxl_word_t & read_data);
+  virtual bool read_double_word_data(const dxl_id_t & id, const dxl_address_t & address,
                              dxl_double_word_t & read_data);
 
  private:

--- a/rt_manipulators_lib/include/hardware_communicator.hpp
+++ b/rt_manipulators_lib/include/hardware_communicator.hpp
@@ -40,9 +40,9 @@ class Communicator{
  public:
   explicit Communicator(const std::string device_name);
   virtual ~Communicator();
-  virtual bool is_connected();
+  bool is_connected();
   virtual bool connect(const int baudrate = 3000000);
-  virtual void disconnect();
+  void disconnect();
   virtual void make_sync_read_group(const group_name_t & group_name, const dxl_address_t & start_address,
                               const dxl_data_length_t & data_length);
   virtual void make_sync_write_group(const group_name_t & group_name, const dxl_address_t & start_address,
@@ -50,12 +50,12 @@ class Communicator{
   virtual bool append_id_to_sync_read_group(const group_name_t & group_name, const dxl_id_t & id);
   virtual bool append_id_to_sync_write_group(const group_name_t & group_name, const dxl_id_t & id,
                                      std::vector<dxl_byte_t> & init_data);
-  virtual bool send_sync_read_packet(const group_name_t & group_name);
-  virtual bool send_sync_write_packet(const group_name_t & group_name);
-  virtual bool get_sync_read_data(const group_name_t & group_name, const dxl_id_t id,
+  bool send_sync_read_packet(const group_name_t & group_name);
+  bool send_sync_write_packet(const group_name_t & group_name);
+  bool get_sync_read_data(const group_name_t & group_name, const dxl_id_t id,
                           const dxl_address_t & address, const dxl_data_length_t & length,
                           dxl_double_word_t & read_data);
-  virtual bool set_sync_write_data(const group_name_t & group_name, const dxl_id_t id,
+  bool set_sync_write_data(const group_name_t & group_name, const dxl_id_t id,
                            std::vector<dxl_byte_t> & write_data);
   virtual bool write_byte_data(const dxl_id_t & id, const dxl_address_t & address,
                        const dxl_byte_t & write_data);

--- a/rt_manipulators_lib/src/hardware.cpp
+++ b/rt_manipulators_lib/src/hardware.cpp
@@ -23,7 +23,12 @@ namespace rt_manipulators_cpp {
 
 Hardware::Hardware(const std::string device_name) :
   thread_enable_(false) {
-  comm_ = std::make_shared<hardware_communicator::Communicator>(device_name);
+  comm_ = std::make_unique<hardware_communicator::Communicator>(device_name);
+}
+
+Hardware::Hardware(std::unique_ptr<hardware_communicator::Communicator> comm) :
+  thread_enable_(false){
+  comm_ = std::move(comm);
 }
 
 Hardware::~Hardware() {

--- a/rt_manipulators_lib/src/hardware.cpp
+++ b/rt_manipulators_lib/src/hardware.cpp
@@ -27,7 +27,7 @@ Hardware::Hardware(const std::string device_name) :
 }
 
 Hardware::Hardware(std::unique_ptr<hardware_communicator::Communicator> comm) :
-  thread_enable_(false){
+  thread_enable_(false) {
   comm_ = std::move(comm);
 }
 

--- a/rt_manipulators_lib/test/CMakeLists.txt
+++ b/rt_manipulators_lib/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(list_tests
     test_dynamixel_x
     test_dynamixel_xh
     test_dynamixel_p
+    test_hardware
 )
 foreach(test_executable IN LISTS list_tests)
     message("${test_executable}")

--- a/rt_manipulators_lib/test/CMakeLists.txt
+++ b/rt_manipulators_lib/test/CMakeLists.txt
@@ -24,6 +24,17 @@ set(list_tests
     test_dynamixel_p
     test_hardware
 )
+
+# Download FakeIt
+Set(FETCHCONTENT_QUIET FALSE)
+include(FetchContent)
+FetchContent_Declare(
+    fakeit
+    GIT_REPOSITORY https://github.com/eranpeer/FakeIt
+    GIT_TAG 2.4.0
+    GIT_PROGRESS TRUE)
+FetchContent_MakeAvailable(fakeit)
+
 foreach(test_executable IN LISTS list_tests)
     message("${test_executable}")
     add_executable(${test_executable}
@@ -33,6 +44,9 @@ foreach(test_executable IN LISTS list_tests)
         GTest::GTest
         GTest::Main
         rt_manipulators_cpp
+    )
+    target_include_directories(${test_executable} PRIVATE
+        ${fakeit_SOURCE_DIR}/single_header/gtest
     )
     gtest_discover_tests(${test_executable})
 endforeach()

--- a/rt_manipulators_lib/test/test_hardware.cpp
+++ b/rt_manipulators_lib/test/test_hardware.cpp
@@ -21,19 +21,33 @@
 
 using namespace fakeit;
 
-TEST(HardwareTest, load_config_file) {
-  // Expect the load_config_file method to be called twice and return true and false respectively.
+Mock<hardware_communicator::Communicator> create_default_mock(void)
+{
   Mock<hardware_communicator::Communicator> mock;
-  When(Method(mock, read_byte_data)).AlwaysReturn(true);
-  When(Method(mock, read_word_data)).AlwaysReturn(true);
-  When(Method(mock, read_double_word_data)).AlwaysReturn(true);
-  When(Method(mock, write_byte_data)).AlwaysReturn(true);
-  When(Method(mock, write_word_data)).AlwaysReturn(true);
-  When(Method(mock, write_double_word_data)).AlwaysReturn(true);
+  When(Method(mock, is_connected)).AlwaysReturn(true);
+  When(Method(mock, connect)).AlwaysReturn(true);
+  When(Method(mock, disconnect)).AlwaysReturn();
   When(Method(mock, make_sync_write_group)).AlwaysReturn();
   When(Method(mock, make_sync_read_group)).AlwaysReturn();
   When(Method(mock, append_id_to_sync_write_group)).AlwaysReturn(true);
   When(Method(mock, append_id_to_sync_read_group)).AlwaysReturn(true);
+  When(Method(mock, send_sync_read_packet)).AlwaysReturn(true);
+  When(Method(mock, send_sync_write_packet)).AlwaysReturn(true);
+  When(Method(mock, get_sync_read_data)).AlwaysReturn(true);
+  When(Method(mock, set_sync_write_data)).AlwaysReturn(true);
+  When(Method(mock, write_byte_data)).AlwaysReturn(true);
+  When(Method(mock, write_word_data)).AlwaysReturn(true);
+  When(Method(mock, write_double_word_data)).AlwaysReturn(true);
+  When(Method(mock, read_byte_data)).AlwaysReturn(true);
+  When(Method(mock, read_word_data)).AlwaysReturn(true);
+  When(Method(mock, read_double_word_data)).AlwaysReturn(true);
+
+  return mock;
+}
+
+TEST(HardwareTest, load_config_file) {
+  // Expect the load_config_file method to be called twice and return true and false respectively.
+  auto mock = create_default_mock();
 
   rt_manipulators_cpp::Hardware hardware(
     std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
@@ -44,7 +58,7 @@ TEST(HardwareTest, load_config_file) {
 
 TEST(HardwareTest, connect) {
   // Expect the connect method to be called twice and return true and false respectively.
-  Mock<hardware_communicator::Communicator> mock;
+  auto mock = create_default_mock();
   When(Method(mock, connect)).Return(true, false);  // Return true then false.
 
   rt_manipulators_cpp::Hardware hardware(
@@ -52,4 +66,20 @@ TEST(HardwareTest, connect) {
 
   EXPECT_TRUE(hardware.connect());
   EXPECT_FALSE(hardware.connect());
+}
+
+TEST(HardwareTest, disconnect) {
+  // Expect the disconnect method to be called once and never.
+  auto mock = create_default_mock();
+  When(Method(mock, is_connected)).Return(false).AlwaysReturn(true); // Return false then true.
+  When(Method(mock, disconnect)).AlwaysReturn();
+
+  rt_manipulators_cpp::Hardware hardware(
+    std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
+
+  hardware.disconnect();
+  fakeit::Verify(Method(mock, disconnect)).Never();
+
+  hardware.disconnect();
+  fakeit::Verify(Method(mock, disconnect)).Once();
 }

--- a/rt_manipulators_lib/test/test_hardware.cpp
+++ b/rt_manipulators_lib/test/test_hardware.cpp
@@ -12,18 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
+#include "fakeit.hpp"
 #include "gtest/gtest.h"
 #include "rt_manipulators_cpp/hardware.hpp"
+#include "rt_manipulators_cpp/hardware_communicator.hpp"
 
+using namespace fakeit;
 
-TEST(HardwareTest, write_data) {
+class HardwareTestFixture: public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    Mock<hardware_communicator::Communicator> mock;
+    When(Method(mock, read_byte_data)).AlwaysReturn(true);
+    When(Method(mock, read_word_data)).AlwaysReturn(true);
+    When(Method(mock, read_double_word_data)).AlwaysReturn(true);
 
-  rt_manipulators_cpp::Hardware hardware("/dev/ttyUSB0");
-  uint16_t test_addr = 0x1234;
-  uint8_t test_data = 0x56;
-  EXPECT_EQ(hardware.write_data("unregistered_id", test_addr, test_data), false);
-  EXPECT_EQ(hardware.write_data(0, test_addr, test_data), false);
+    hardware = std::make_shared<rt_manipulators_cpp::Hardware>(
+      std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
+  }
 
-  hardware.load_config_file("../config/ok_single_joint.yaml");
-  EXPECT_EQ(hardware.write_data("joint1", test_addr, test_data), true);
+  virtual void TearDown() {
+  }
+
+  std::shared_ptr<rt_manipulators_cpp::Hardware> hardware;
+};
+
+TEST_F(HardwareTestFixture, load_config_file) {
+  EXPECT_TRUE(hardware->load_config_file("../config/ok_single_joint.yaml"));
 }

--- a/rt_manipulators_lib/test/test_hardware.cpp
+++ b/rt_manipulators_lib/test/test_hardware.cpp
@@ -21,24 +21,35 @@
 
 using namespace fakeit;
 
-class HardwareTestFixture: public ::testing::Test {
- protected:
-  virtual void SetUp() {
-    Mock<hardware_communicator::Communicator> mock;
-    When(Method(mock, read_byte_data)).AlwaysReturn(true);
-    When(Method(mock, read_word_data)).AlwaysReturn(true);
-    When(Method(mock, read_double_word_data)).AlwaysReturn(true);
+TEST(HardwareTest, load_config_file) {
+  // Expect the load_config_file method to be called twice and return true and false respectively.
+  Mock<hardware_communicator::Communicator> mock;
+  When(Method(mock, read_byte_data)).AlwaysReturn(true);
+  When(Method(mock, read_word_data)).AlwaysReturn(true);
+  When(Method(mock, read_double_word_data)).AlwaysReturn(true);
+  When(Method(mock, write_byte_data)).AlwaysReturn(true);
+  When(Method(mock, write_word_data)).AlwaysReturn(true);
+  When(Method(mock, write_double_word_data)).AlwaysReturn(true);
+  When(Method(mock, make_sync_write_group)).AlwaysReturn();
+  When(Method(mock, make_sync_read_group)).AlwaysReturn();
+  When(Method(mock, append_id_to_sync_write_group)).AlwaysReturn(true);
+  When(Method(mock, append_id_to_sync_read_group)).AlwaysReturn(true);
 
-    hardware = std::make_shared<rt_manipulators_cpp::Hardware>(
-      std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
-  }
+  rt_manipulators_cpp::Hardware hardware(
+    std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
 
-  virtual void TearDown() {
-  }
+  EXPECT_TRUE(hardware.load_config_file("../config/ok_has_dynamixel_name.yaml"));
+  EXPECT_FALSE(hardware.load_config_file("../config/ng_has_same_joints.yaml"));
+}
 
-  std::shared_ptr<rt_manipulators_cpp::Hardware> hardware;
-};
+TEST(HardwareTest, connect) {
+  // Expect the connect method to be called twice and return true and false respectively.
+  Mock<hardware_communicator::Communicator> mock;
+  When(Method(mock, connect)).Return(true, false);  // Return true then false.
 
-TEST_F(HardwareTestFixture, load_config_file) {
-  EXPECT_TRUE(hardware->load_config_file("../config/ok_single_joint.yaml"));
+  rt_manipulators_cpp::Hardware hardware(
+    std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
+
+  EXPECT_TRUE(hardware.connect());
+  EXPECT_FALSE(hardware.connect());
 }

--- a/rt_manipulators_lib/test/test_hardware.cpp
+++ b/rt_manipulators_lib/test/test_hardware.cpp
@@ -19,10 +19,11 @@
 #include "rt_manipulators_cpp/hardware.hpp"
 #include "rt_manipulators_cpp/hardware_communicator.hpp"
 
-using namespace fakeit;
+using fakeit::Mock;
+using fakeit::Verify;
+using fakeit::When;
 
-Mock<hardware_communicator::Communicator> create_default_mock(void)
-{
+Mock<hardware_communicator::Communicator> create_default_mock(void) {
   Mock<hardware_communicator::Communicator> mock;
   When(Method(mock, is_connected)).AlwaysReturn(true);
   When(Method(mock, connect)).AlwaysReturn(true);
@@ -71,15 +72,15 @@ TEST(HardwareTest, connect) {
 TEST(HardwareTest, disconnect) {
   // Expect the disconnect method to be called once and never.
   auto mock = create_default_mock();
-  When(Method(mock, is_connected)).Return(false).AlwaysReturn(true); // Return false then true.
+  When(Method(mock, is_connected)).Return(false).AlwaysReturn(true);  // Return false then true.
   When(Method(mock, disconnect)).AlwaysReturn();
 
   rt_manipulators_cpp::Hardware hardware(
     std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
 
   hardware.disconnect();
-  fakeit::Verify(Method(mock, disconnect)).Never();
+  Verify(Method(mock, disconnect)).Never();
 
   hardware.disconnect();
-  fakeit::Verify(Method(mock, disconnect)).Once();
+  Verify(Method(mock, disconnect)).Once();
 }

--- a/rt_manipulators_lib/test/test_hardware.cpp
+++ b/rt_manipulators_lib/test/test_hardware.cpp
@@ -1,0 +1,29 @@
+// Copyright 2023 RT Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "rt_manipulators_cpp/hardware.hpp"
+
+
+TEST(HardwareTest, write_data) {
+
+  rt_manipulators_cpp::Hardware hardware("/dev/ttyUSB0");
+  uint16_t test_addr = 0x1234;
+  uint8_t test_data = 0x56;
+  EXPECT_EQ(hardware.write_data("unregistered_id", test_addr, test_data), false);
+  EXPECT_EQ(hardware.write_data(0, test_addr, test_data), false);
+
+  hardware.load_config_file("../config/ok_single_joint.yaml");
+  EXPECT_EQ(hardware.write_data("joint1", test_addr, test_data), true);
+}

--- a/rt_manipulators_lib/test/test_hardware.cpp
+++ b/rt_manipulators_lib/test/test_hardware.cpp
@@ -23,7 +23,7 @@ using fakeit::Mock;
 using fakeit::Verify;
 using fakeit::When;
 
-Mock<hardware_communicator::Communicator> create_default_mock(void) {
+Mock<hardware_communicator::Communicator> create_comm_mock(void) {
   Mock<hardware_communicator::Communicator> mock;
   When(Method(mock, is_connected)).AlwaysReturn(true);
   When(Method(mock, connect)).AlwaysReturn(true);
@@ -48,7 +48,7 @@ Mock<hardware_communicator::Communicator> create_default_mock(void) {
 
 TEST(HardwareTest, load_config_file) {
   // Expect the load_config_file method to be called twice and return true and false respectively.
-  auto mock = create_default_mock();
+  auto mock = create_comm_mock();
 
   rt_manipulators_cpp::Hardware hardware(
     std::unique_ptr<hardware_communicator::Communicator>(&mock.get()));
@@ -59,7 +59,7 @@ TEST(HardwareTest, load_config_file) {
 
 TEST(HardwareTest, connect) {
   // Expect the connect method to be called twice and return true and false respectively.
-  auto mock = create_default_mock();
+  auto mock = create_comm_mock();
   When(Method(mock, connect)).Return(true, false);  // Return true then false.
 
   rt_manipulators_cpp::Hardware hardware(
@@ -71,7 +71,7 @@ TEST(HardwareTest, connect) {
 
 TEST(HardwareTest, disconnect) {
   // Expect the disconnect method to be called once and never.
-  auto mock = create_default_mock();
+  auto mock = create_comm_mock();
   When(Method(mock, is_connected)).Return(false).AlwaysReturn(true);  // Return false then true.
   When(Method(mock, disconnect)).AlwaysReturn();
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

Hardware classのためのユニットテスト環境を追加します。

## Hardwareクラスの変更について

Hardwareのテストをする際に、通信部分（Communicator）の処理を制御しなければなりません。
そのため、Communicatorをmock化します。

また、mock化したCommunicatorをセットできるコンストラクタを追加します。
Hardware外部でCommunicatorを悪用されないように、unique_ptrで渡しています。
（Hardware内では、通信機能を共有するためshared_ptrのままです）

## Communicatorクラスの変更について

mock化するため、全てのpublic関数を仮想関数化しました。

## ユニットテストについて

この変更ではユニットテスト環境を用意することを目的にしています。
そのため、load_config_file、connect、disconnectのみをテストします。

## mock用のライブラリFakeItについて

google testでもmock化はできますが、mockクラスが必要になります。
そのため、mockクラスを作らなくて良い、FakeItを採択しました。

FakeItはヘッダーオンリーなライブラリなので、CMakeListsのFetchContent機能でgit cloneできます。

リポジトリ：https://github.com/eranpeer/FakeIt
使い方：https://github.com/eranpeer/FakeIt/wiki/Quickstart

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

ローカル環境で`./run_test_library.bash`が通ることを確認しました。

また、CIでのテストも確認します。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
