### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/rt_manipulators_examples/CMakeLists.txt
+++ b/rt_manipulators_examples/CMakeLists.txt
@@ -16,9 +16,9 @@ find_package(rclcpp REQUIRED)
 find_package(rt_manipulators_cpp REQUIRED)
 
 add_executable(x7_forward_kinematics src/x7_forward_kinematics.cpp)
-ament_target_dependencies(x7_forward_kinematics
-  rclcpp
-  rt_manipulators_cpp
+target_link_libraries(x7_forward_kinematics
+  rclcpp::rclcpp
+  rt_manipulators_cpp::rt_manipulators_cpp
 )
 
 if(BUILD_TESTING)

--- a/rt_manipulators_lib/CMakeLists.txt
+++ b/rt_manipulators_lib/CMakeLists.txt
@@ -38,13 +38,11 @@ target_include_directories(${library_name}
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
+
 target_link_libraries(${library_name}
-    yaml-cpp
-)
-ament_target_dependencies(${library_name}
-    dynamixel_sdk
-    Eigen3
-    yaml_cpp_vendor
+    dynamixel_sdk::dynamixel_sdk
+    Eigen3::Eigen
+    yaml-cpp::yaml-cpp
 )
 
 ament_export_targets(export_${library_name} HAS_LIBRARY_TARGET)
@@ -53,6 +51,7 @@ ament_export_dependencies(
     eigen3_cmake_module
     Eigen3
     yaml_cpp_vendor
+    yaml-cpp
 )
 install(
   DIRECTORY include/

--- a/rt_manipulators_lib/src/CMakeLists.txt
+++ b/rt_manipulators_lib/src/CMakeLists.txt
@@ -25,10 +25,9 @@ set_target_properties(${library_name} PROPERTIES VERSION 1.1.0 SOVERSION 1)
 target_include_directories(${library_name} PUBLIC
     ${PROJECT_SOURCE_DIR}/include
 )
-message("${CMAKE_THREAD_LIBS_INIT}")
 target_link_libraries(${library_name} PUBLIC
-    ${YAML_CPP_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
+    yaml-cpp::yaml-cpp
+    Threads::Threads
     dxl_x64_cpp
 )
 


### PR DESCRIPTION
Require https://github.com/ROBOTIS-GIT/DynamixelSDK/pull/653

`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.
